### PR TITLE
slirp4netns: add -r FD

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -5,7 +5,7 @@ AM_CFLAGS = -I $(abs_top_srcdir)/rd235_libslirp/include -I$(abs_top_srcdir)/rd23
 noinst_LIBRARIES = libqemu_slirp.a libslirp.a
 
 AM_TESTS_ENVIRONMENT = PATH="$(abs_top_builddir):$(PATH)"
-TESTS = tests/test-slirp4netns.sh tests/test-slirp4netns-configure.sh tests/test-slirp4netns-exit-fd.sh
+TESTS = tests/test-slirp4netns.sh tests/test-slirp4netns-configure.sh tests/test-slirp4netns-exit-fd.sh tests/test-slirp4netns-ready-fd.sh
 
 EXTRA_DIST = \
 	slirp4netns.1.md \

--- a/slirp4netns.1
+++ b/slirp4netns.1
@@ -1,4 +1,3 @@
-.nh
 .TH SLIRP4NETNS 1 "July 2018" "Rootless Containers" "User Commands"
 
 .SH NAME
@@ -17,16 +16,12 @@ slirp4netns provides a user\-mode networking ("slirp") for unprivileged network 
 
 .PP
 Default configuration:
-
-.RS
 .IP \(bu 2
 Gateway: 10.0.2.2
 .IP \(bu 2
 DNS: 10.0.2.3
 .IP \(bu 2
 Host: 10.0.2.2, 10.0.2.3
-
-.RE
 
 
 .SH OPTIONS
@@ -36,7 +31,11 @@ bring up the interface. IP will be set to 10.0.2.100.
 
 .PP
 \fB\-e FD\fP
-specify FD for terminating slirp4netns.
+specify the FD for terminating slirp4netns.
+
+.PP
+\fB\-r FD\fP
+specify the FD to write to when the network is configured.
 
 
 .SH EXAMPLE
@@ -92,4 +91,5 @@ unshared$ curl https://example.com
 
 .SH AVAILABILITY
 .PP
-The slirp4netns command is available from \fBhttps://github.com/rootless\-containers/slirp4netns\fP under GNU GENERAL PUBLIC LICENSE Version 2.
+The slirp4netns command is available from \fB
+\[la]https://github.com/rootless-containers/slirp4netns\[ra]\fP under GNU GENERAL PUBLIC LICENSE Version 2.

--- a/slirp4netns.1.md
+++ b/slirp4netns.1.md
@@ -25,7 +25,10 @@ Default configuration:
 bring up the interface. IP will be set to 10.0.2.100.
 
 **-e FD**
-specify FD for terminating slirp4netns.
+specify the FD for terminating slirp4netns.
+
+**-r FD**
+specify the FD to write to when the network is configured.
 
 # EXAMPLE
 

--- a/tests/test-slirp4netns-ready-fd.sh
+++ b/tests/test-slirp4netns-ready-fd.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -xeuo pipefail
+
+. $(dirname $0)/common.sh
+
+unshare -r -n sleep infinity &
+child=$!
+
+wait_for_network_namespace $child
+
+touch keep_alive
+
+slirp4netns -c -r 10 $child tun11 10>configured &
+slirp_pid=$!
+
+function cleanup {
+    set +xeuo pipefail
+    kill -9 $child $slirp_pid
+    rm -f configured
+}
+trap cleanup EXIT
+
+wait_for_network_device $child tun11
+
+grep 1 configured
+
+exit 0


### PR DESCRIPTION
There is a race now where it is not possible to know when the network
namespace is configured, unless the caller polls for the new device to
be up.

Add a new function to immediately notify the caller when the network
is configured.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>