### PR TITLE
ignore SIGPIPE

### DIFF
--- a/slirp4netns.c
+++ b/slirp4netns.c
@@ -1,6 +1,7 @@
 #define _GNU_SOURCE
 #include <assert.h>
 #include <stdio.h>
+#include <signal.h>
 #include <arpa/inet.h>
 
 #include "qemu/slirp/slirp.h"
@@ -68,6 +69,7 @@ int do_slirp(int tapfd, int exitfd)
 		n_fds++;
 		g_array_append_val(&pollfds, exit_pollfd);
 	}
+	signal(SIGPIPE, SIG_IGN);
 	while (1) {
 		int pollout;
 		uint32_t timeout = -1;


### PR DESCRIPTION
Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>

Fix #13 
@giuseppe PTAL

Maybe we could use `MSG_NOSIGNAL` instead.
