### PR TITLE
slirp4netns: include version in status output

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -66,6 +66,7 @@ libqemu_slirp_a_SOURCES = \
 
 libslirp_a_SOURCES = rd235_libslirp/src/qemu2libslirp.c
 
+slirp4netns_CFLAGS = $(AM_CFLAGS) -DGIT_VERSION=\""$(shell git rev-parse HEAD || true)"\"
 slirp4netns_SOURCES = main.c slirp4netns.c
 slirp4netns_LDADD = libslirp.a libqemu_slirp.a
 man1_MANS = slirp4netns.1

--- a/main.c
+++ b/main.c
@@ -1,4 +1,5 @@
 #define _GNU_SOURCE
+#include <config.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -242,6 +243,8 @@ static void usage(const char *argv0)
 	printf("-r, --ready-fd=FD    specify the FD to write to when the network is configured\n");
 	printf("-m, --mtu=MTU        specify MTU (default=1500, max=65521)\n");
 	printf("-6, --enable-ipv6    enable IPv6 (experimental)\n");
+	printf("\n");
+	printf("Version: %s\n", GIT_VERSION[0] ? GIT_VERSION : PACKAGE_VERSION);
 }
 
 struct options {


### PR DESCRIPTION
Closes: https://github.com/rootless-containers/slirp4netns/issues/22

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>