### PR TITLE
include commit hash in status output

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-main.c export-subst
+Makefile.am export-subst

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+main.c export-subst

--- a/Makefile.am
+++ b/Makefile.am
@@ -66,9 +66,15 @@ libqemu_slirp_a_SOURCES = \
 
 libslirp_a_SOURCES = rd235_libslirp/src/qemu2libslirp.c
 
-VERSION := $(shell [ -d .git ] && echo "-DVERSION=\\\"$$(git describe --always --abbrev)\\\"")
+# define specific version if commit information available or was
+# replaced during git-archive creation
+VERSION := $(shell V=$Format:%h$ ; \
+	expr match "$$V" ormat: >/dev/null \
+		&& ([ -d .git ] && git describe --always --abbrev || echo unknown) \
+		|| echo "$$V" )
+DEFINE_VERSION = -DVERSION="\"$(VERSION)\""
 
-slirp4netns_CFLAGS = $(AM_CFLAGS) $(VERSION)
+slirp4netns_CFLAGS = $(AM_CFLAGS) $(DEFINE_VERSION)
 slirp4netns_SOURCES = main.c slirp4netns.c
 slirp4netns_LDADD = libslirp.a libqemu_slirp.a
 man1_MANS = slirp4netns.1

--- a/Makefile.am
+++ b/Makefile.am
@@ -68,13 +68,13 @@ libslirp_a_SOURCES = rd235_libslirp/src/qemu2libslirp.c
 
 # define specific version if commit information available or was
 # replaced during git-archive creation
-VERSION := $(shell V=$Format:%h$ ; \
+COMMIT := $(shell V=$Format:%h$ ; \
 	expr match "$$V" ormat: >/dev/null \
 		&& ([ -d .git ] && git describe --always --abbrev || echo unknown) \
 		|| echo "$$V" )
-DEFINE_VERSION = -DVERSION="\"$(VERSION)\""
+DEFINE_COMMIT = -DCOMMIT="\"$(COMMIT)\""
 
-slirp4netns_CFLAGS = $(AM_CFLAGS) $(DEFINE_VERSION)
+slirp4netns_CFLAGS = $(AM_CFLAGS) $(DEFINE_COMMIT)
 slirp4netns_SOURCES = main.c slirp4netns.c
 slirp4netns_LDADD = libslirp.a libqemu_slirp.a
 man1_MANS = slirp4netns.1

--- a/Makefile.am
+++ b/Makefile.am
@@ -66,11 +66,10 @@ libqemu_slirp_a_SOURCES = \
 
 libslirp_a_SOURCES = rd235_libslirp/src/qemu2libslirp.c
 
-# define specific version if commit information available or was
-# replaced during git-archive creation
+# define specific commit if git available or it was replaced during git-archive creation
 COMMIT := $(shell V=$Format:%h$ ; \
 	expr match "$$V" ormat: >/dev/null \
-		&& ([ -d .git ] && git describe --always --abbrev || echo unknown) \
+		&& (cd "$$abs_srcdir" && [ -d .git ] && git describe --always --long --dirty || echo unknown) \
 		|| echo "$$V" )
 DEFINE_COMMIT = -DCOMMIT="\"$(COMMIT)\""
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -66,6 +66,9 @@ libqemu_slirp_a_SOURCES = \
 
 libslirp_a_SOURCES = rd235_libslirp/src/qemu2libslirp.c
 
+VERSION := $(shell [ -d .git ] && echo "-DVERSION=\\\"$$(git describe --always --abbrev)\\\"")
+
+slirp4netns_CFLAGS = $(AM_CFLAGS) $(VERSION)
 slirp4netns_SOURCES = main.c slirp4netns.c
 slirp4netns_LDADD = libslirp.a libqemu_slirp.a
 man1_MANS = slirp4netns.1

--- a/Makefile.am
+++ b/Makefile.am
@@ -67,9 +67,9 @@ libqemu_slirp_a_SOURCES = \
 libslirp_a_SOURCES = rd235_libslirp/src/qemu2libslirp.c
 
 # define specific commit if git available or it was replaced during git-archive creation
-COMMIT := $(shell V=$Format:%h$ ; \
+COMMIT := $(shell V=$Format:%H$ ; \
 	expr match "$$V" ormat: >/dev/null \
-		&& (cd "$$abs_srcdir" && [ -d .git ] && git describe --always --long --dirty || echo unknown) \
+		&& (cd "$$abs_srcdir" && [ -d .git ] && git describe --always --abbrev=0 --dirty --exclude=\* || echo unknown) \
 		|| echo "$$V" )
 DEFINE_COMMIT = -DCOMMIT="\"$(COMMIT)\""
 
@@ -93,6 +93,7 @@ indent:
 # indent(1): "You must use the ‘-T’ option to tell indent the name of all the typenames in your program that are defined by typedef."
 	indent -linux -l120 -T ssize_t -T pid_t -T SLIRP $(slirp4netns_SOURCES)
 	$(RM) *.c~
+
 
 benchmark:
 	benchmarks/benchmark-iperf3.sh

--- a/main.c
+++ b/main.c
@@ -233,8 +233,9 @@ static int parent(int sock, int exit_fd, unsigned int mtu, bool enable_ipv6)
 	return 0;
 }
 
+// fallback if VERSION is undefined
 #ifndef VERSION
-#define VERSION "$Format:%h$"
+#define VERSION "unknown"
 #endif
 
 static void usage(const char *argv0)
@@ -246,8 +247,7 @@ static void usage(const char *argv0)
 	printf("-r, --ready-fd=FD    specify the FD to write to when the network is configured\n");
 	printf("-m, --mtu=MTU        specify MTU (default=1500, max=65521)\n");
 	printf("-6, --enable-ipv6    enable IPv6 (experimental)\n");
-	printf("\n");
-	printf("Version: %s\n", VERSION);
+	printf("\nVersion: %s\n", VERSION);
 }
 
 struct options {

--- a/main.c
+++ b/main.c
@@ -1,4 +1,5 @@
 #define _GNU_SOURCE
+#include <config.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -233,10 +234,6 @@ static int parent(int sock, int exit_fd, unsigned int mtu, bool enable_ipv6)
 	return 0;
 }
 
-// fallback if commit hash is not defined
-#ifndef COMMIT
-#define COMMIT "unknown"
-#endif
 
 static void usage(const char *argv0)
 {
@@ -247,7 +244,15 @@ static void usage(const char *argv0)
 	printf("-r, --ready-fd=FD    specify the FD to write to when the network is configured\n");
 	printf("-m, --mtu=MTU        specify MTU (default=1500, max=65521)\n");
 	printf("-6, --enable-ipv6    enable IPv6 (experimental)\n");
-	printf("\nVersion: %s\n", COMMIT);
+	printf("-v, --version        show version and exit\n");
+}
+
+static void version(const char *argv0)
+{
+	printf("%s version %s\n", argv0, VERSION ? VERSION : PACKAGE_VERSION);
+#ifdef COMMIT
+	printf("commit: %s\n", COMMIT);
+#endif
 }
 
 struct options {
@@ -288,10 +293,11 @@ static void parse_args(int argc, char *const argv[], struct options *options)
 		{"ready-fd", required_argument, NULL, 'r'},
 		{"mtu", required_argument, NULL, 'm'},
 		{"enable-ipv6", no_argument, NULL, '6'},
+		{"version", no_argument, NULL, 'v'},
 		{0, 0, 0, 0},
 	};
 	options_init(options);
-	while ((opt = getopt_long(argc, argv, "ce:r:m:6", longopts, NULL)) != -1) {
+	while ((opt = getopt_long(argc, argv, "ce:r:m:6v", longopts, NULL)) != -1) {
 		switch (opt) {
 		case 'c':
 			options->do_config_network = true;
@@ -327,6 +333,9 @@ static void parse_args(int argc, char *const argv[], struct options *options)
 			options->enable_ipv6 = true;
 			printf("WARNING: Support for IPv6 is experimental\n");
 			break;
+		case 'v':
+			version(argv[0]);
+			exit(EXIT_SUCCESS);
 		default:
 			usage(argv[0]);
 			exit(EXIT_FAILURE);

--- a/main.c
+++ b/main.c
@@ -233,9 +233,9 @@ static int parent(int sock, int exit_fd, unsigned int mtu, bool enable_ipv6)
 	return 0;
 }
 
-// fallback if VERSION is undefined
-#ifndef VERSION
-#define VERSION "unknown"
+// fallback if commit hash is not defined
+#ifndef COMMIT
+#define COMMIT "unknown"
 #endif
 
 static void usage(const char *argv0)
@@ -247,7 +247,7 @@ static void usage(const char *argv0)
 	printf("-r, --ready-fd=FD    specify the FD to write to when the network is configured\n");
 	printf("-m, --mtu=MTU        specify MTU (default=1500, max=65521)\n");
 	printf("-6, --enable-ipv6    enable IPv6 (experimental)\n");
-	printf("\nVersion: %s\n", VERSION);
+	printf("\nVersion: %s\n", COMMIT);
 }
 
 struct options {

--- a/main.c
+++ b/main.c
@@ -233,6 +233,10 @@ static int parent(int sock, int exit_fd, unsigned int mtu, bool enable_ipv6)
 	return 0;
 }
 
+#ifndef VERSION
+#define VERSION "$Format:%h$"
+#endif
+
 static void usage(const char *argv0)
 {
 	printf("Usage: %s [OPTION]... PID TAPNAME\n", argv0);
@@ -242,6 +246,8 @@ static void usage(const char *argv0)
 	printf("-r, --ready-fd=FD    specify the FD to write to when the network is configured\n");
 	printf("-m, --mtu=MTU        specify MTU (default=1500, max=65521)\n");
 	printf("-6, --enable-ipv6    enable IPv6 (experimental)\n");
+	printf("\n");
+	printf("Version: %s\n", VERSION);
 }
 
 struct options {


### PR DESCRIPTION
This is an alternative to #34 and fixes #22.

* all commit hash definition logic is done in a subshell in the makefile
* both the makefile shell and preprocessor directives in `main.c` fallback to `unknown` if the git command fails or `VERSION` is somehow undefined during compilation
* the subshell uses `git describe` output when building from a checked-out repository or an inserted commit hash when building from a git-archive (i.e. a downloaded tarball)
* [lines 71-74](https://github.com/rootless-containers/slirp4netns/blob/e9dddfb60966e6dd971631e3cda0fdd6403d8d75/Makefile.am#L71) should be reusable for other projects and languages