### PR TITLE
[WIP] slirp4netns: support using qemu for setting up the slirp network

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,9 +1,6 @@
 bin_PROGRAMS = slirp4netns
 
 AM_CFLAGS = -I $(abs_top_srcdir)/rd235_libslirp/include -I$(abs_top_srcdir)/rd235_libslirp/src -I$(abs_top_srcdir)/qemu/include -I$(abs_top_srcdir)/qemu/slirp
-
-noinst_LIBRARIES = libqemu_slirp.a libslirp.a
-
 AM_TESTS_ENVIRONMENT = PATH="$(abs_top_builddir):$(PATH)"
 TESTS = tests/test-slirp4netns.sh tests/test-slirp4netns-configure.sh tests/test-slirp4netns-exit-fd.sh tests/test-slirp4netns-ready-fd.sh
 
@@ -75,7 +72,11 @@ DEFINE_COMMIT = -DCOMMIT="\"$(COMMIT)\""
 
 slirp4netns_CFLAGS = $(AM_CFLAGS) $(DEFINE_COMMIT)
 slirp4netns_SOURCES = main.c slirp4netns.c
+if BUILD_LIBSLIRP
+noinst_LIBRARIES = libqemu_slirp.a libslirp.a
 slirp4netns_LDADD = libslirp.a libqemu_slirp.a
+endif
+
 man1_MANS = slirp4netns.1
 
 generate-man:

--- a/configure.ac
+++ b/configure.ac
@@ -30,5 +30,13 @@ AC_FUNC_MALLOC
 AC_FUNC_REALLOC
 AC_CHECK_FUNCS([atexit clock_gettime inet_ntoa memmove memset socket strchr strdup strerror strstr strtol getopt_long])
 
+AC_ARG_WITH(system-qemu,
+	[AC_HELP_STRING([--with-system-qemu], [define if using qemu for managing the slirp network (not all functionalities will be supported)])],
+	[with_system_qemu=$withval], [with_system_qemu=])
+if test -n "$with_system_qemu"; then
+	AC_DEFINE_UNQUOTED([SYSTEM_QEMU_PATH], "$with_system_qemu", [Define the path to the qemu executable to use])
+fi
+AM_CONDITIONAL([BUILD_LIBSLIRP], [test -z "$with_system_qemu"])
+
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT


### PR DESCRIPTION
it is not possible to use the system qemu for setting up and managing
the slirp network.

Add a --with-system-qemu build option, when it is specified the
libslirp code is not built in and the qemu executable is launched for
managing the network.  Some features like setting up the mtu are not
honored when system-qemu is used.

Closes: https://github.com/rootless-containers/slirp4netns/issues/30

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>