### PR TITLE
use version string from git tags (similar to git describe)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-Makefile.am export-subst
+version.sh export-subst

--- a/Makefile.am
+++ b/Makefile.am
@@ -67,13 +67,10 @@ libqemu_slirp_a_SOURCES = \
 libslirp_a_SOURCES = rd235_libslirp/src/qemu2libslirp.c
 
 # define specific commit if git available or it was replaced during git-archive creation
-COMMIT := $(shell V=$Format:%H$ ; \
-	expr match "$$V" ormat: >/dev/null \
-		&& (cd "$$abs_srcdir" && [ -d .git ] && git describe --always --abbrev=0 --dirty --exclude=\* || echo unknown) \
-		|| echo "$$V" )
-DEFINE_COMMIT = -DCOMMIT="\"$(COMMIT)\""
+COMMIT     := $(shell sh ./version.sh commit)
+GITVERSION := $(shell sh ./version.sh version)
 
-slirp4netns_CFLAGS = $(AM_CFLAGS) $(DEFINE_COMMIT)
+slirp4netns_CFLAGS = $(AM_CFLAGS) -DCOMMIT="\"$(COMMIT)\"" -DGITVERSION="\"$(GITVERSION)\""
 slirp4netns_SOURCES = main.c slirp4netns.c
 slirp4netns_LDADD = libslirp.a libqemu_slirp.a
 man1_MANS = slirp4netns.1

--- a/Makefile.am
+++ b/Makefile.am
@@ -66,11 +66,7 @@ libqemu_slirp_a_SOURCES = \
 
 libslirp_a_SOURCES = rd235_libslirp/src/qemu2libslirp.c
 
-# define specific commit if git available or it was replaced during git-archive creation
-COMMIT     := $(shell sh ./version.sh commit)
-GITVERSION := $(shell sh ./version.sh version)
-
-slirp4netns_CFLAGS = $(AM_CFLAGS) -DCOMMIT="\"$(COMMIT)\"" -DGITVERSION="\"$(GITVERSION)\""
+slirp4netns_CFLAGS = $(AM_CFLAGS)
 slirp4netns_SOURCES = main.c slirp4netns.c
 slirp4netns_LDADD = libslirp.a libqemu_slirp.a
 man1_MANS = slirp4netns.1

--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,8 @@
 AC_PREREQ([2.69])
-AC_INIT([slirp4netns], [unversioned], [https://github.com/rootless-containers/slirp4netns/issues])
+AC_INIT([slirp4netns], [m4_esyscmd_s([sh version.sh version])], [https://github.com/rootless-containers/slirp4netns/issues])
 AC_CONFIG_SRCDIR([main.c])
 AC_CONFIG_HEADERS([config.h])
+AC_DEFINE_UNQUOTED([COMMIT], "`sh version.sh commit`", "Git commit from which we build")
 
 AC_PROG_CC
 AC_PROG_RANLIB

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.69])
-AC_INIT([slirp4netns], [0.1], [https://github.com/rootless-containers/slirp4netns/issues])
+AC_INIT([slirp4netns], [unversioned], [https://github.com/rootless-containers/slirp4netns/issues])
 AC_CONFIG_SRCDIR([main.c])
 AC_CONFIG_HEADERS([config.h])
 

--- a/main.c
+++ b/main.c
@@ -250,6 +250,9 @@ static void usage(const char *argv0)
 // version output is runc-compatible and machine-parsable
 static void version()
 {
+#ifndef GITVERSION
+#define GITVERSION VERSION
+#endif
 	printf("slirp4netns version %s\n", GITVERSION ? GITVERSION : PACKAGE_VERSION);
 #ifdef COMMIT
 	printf("commit: %s\n", COMMIT);

--- a/main.c
+++ b/main.c
@@ -250,10 +250,7 @@ static void usage(const char *argv0)
 // version output is runc-compatible and machine-parsable
 static void version()
 {
-#ifndef GITVERSION
-#define GITVERSION VERSION
-#endif
-	printf("slirp4netns version %s\n", GITVERSION ? GITVERSION : PACKAGE_VERSION);
+	printf("slirp4netns version %s\n", VERSION ? VERSION : PACKAGE_VERSION);
 #ifdef COMMIT
 	printf("commit: %s\n", COMMIT);
 #endif

--- a/main.c
+++ b/main.c
@@ -250,7 +250,7 @@ static void usage(const char *argv0)
 // version output is runc-compatible and machine-parsable
 static void version()
 {
-	printf("slirp4netns version %s\n", VERSION ? VERSION : PACKAGE_VERSION);
+	printf("slirp4netns version %s\n", GITVERSION ? GITVERSION : PACKAGE_VERSION);
 #ifdef COMMIT
 	printf("commit: %s\n", COMMIT);
 #endif

--- a/version.sh
+++ b/version.sh
@@ -1,0 +1,66 @@
+#!/bin/sh
+
+# Copyright (c) 2018 Anton Semjonov
+# Licensed under the MIT License
+
+#-------------------------------------------#
+#                                           #
+#  This script prints version information   #
+#         when executed in a shell:         #
+#                                           #
+#             sh ./version.sh               #
+#                                           #
+#         For more information see:         #
+#   https://github.com/ansemjo/version.sh   #
+#                                           #
+#-------------------------------------------#
+
+# Ignore warnings about necessary single-quotes and literal newlines for POSIX compatability:
+# shellcheck disable=SC2016,SC1004
+
+# add 'VERSION export-subst' in .gitattributes and
+# these strings will be substituted by git-archive
+COMMIT='$Format:%H$'
+REFS='$Format:%D$'
+
+# constants
+FALLBACK_VERSION='commit'
+FALLBACK_COMMIT='unknown'
+REVISION='.r'
+
+# check if variable contains a subst value or still has the format string
+hasval() { expr "$1" : '$Format' == 0 >/dev/null; }
+
+# parse the %D reflist to get tag or branch
+refparse() { REF="$1";
+  tag=$(echo "$REF" | sed -ne 's/.*tag: \([^,]*\).*/\1/p'); test -n "$tag" && echo "$tag" && return 0;
+  branch=$(echo "$REF" | sed -e 's/HEAD -> //' -e 's/, /\
+/' | sed -ne '/^[a-z0-9._-]*$/p' | sed -n '1p'); test -n "$branch" && echo "$branch" && return 0;
+  return 1; }
+
+# git functions to return commit and version in repository
+hasgit() { test -d .git; }
+gitcommit() { hasgit && git describe --always --abbrev=0 --match '^$' --dirty; }
+gitversion() { hasgit \
+  && { V=$(git describe 2>/dev/null) && echo "$V" | sed 's/-\([0-9]*\)-g.*/'"$REVISION"'\1/'; } \
+  || { C=$(git rev-list --count HEAD) && printf '0.0.0%s%s' "$REVISION" "$C"; };
+}
+
+# wrappers
+version() { hasval "$REFS" && refparse "$REFS" || gitversion || echo "$FALLBACK_VERSION"; }
+commit()  { hasval "$COMMIT" && echo "$COMMIT" || gitcommit || echo "$FALLBACK_COMMIT";  }
+describe() { printf '%s-g%.7s\n' "$(version)" "$(commit)"; }
+
+# ---------------------------------
+
+case "$1" in
+  version)  version ;;
+  commit)   commit ;;
+  describe) describe ;;
+  json)
+    printf '{\n  "version": "%s",\n  "commit": "%s",\n  "describe":"%s"\n}\n' "$(version)" "$(commit)" "$(describe)" ;;
+  help)
+    printf '%s [version|commit|describe|json]\n' "$0" ;;
+  *)
+    printf 'version : %s\ncommit  : %s\n' "$(version)" "$(commit)" ;;
+esac

--- a/version.sh
+++ b/version.sh
@@ -15,21 +15,25 @@
 #                                           #
 #-------------------------------------------#
 
-# Ignore warnings about necessary single-quotes and literal newlines for POSIX compatability:
+# Ignore certain shellcheck warnings:
+#  - $Format.. looks like a variable in single-quotes but is necessary so it does _not_ expand
+#  - backslash before a literal newline is a portable way to insert newlines with sed
 # shellcheck disable=SC2016,SC1004
 
-# add 'VERSION export-subst' in .gitattributes and
-# these strings will be substituted by git-archive
+# Add the following line in .gitattributes so these strings are substituted by git-archive:
+#   version.sh export-subst
 COMMIT='$Format:%H$'
 REFS='$Format:%D$'
 
-# constants
+# Fallback values
 FALLBACK_VERSION='commit'
 FALLBACK_COMMIT='unknown'
-REVISION='.r'
+
+# Revision seperator in 'describe' string
+REVISION='-'
 
 # check if variable contains a subst value or still has the format string
-hasval() { expr "$1" : '$Format' == 0 >/dev/null; }
+hasval() { test -n "${1##\$Format*}"; }
 
 # parse the %D reflist to get tag or branch
 refparse() { REF="$1";


### PR DESCRIPTION
Prepare for #44.

Uses [ansemjo/version.sh](https://github.com/ansemjo/version.sh) to parse both commit and version string either from checked-out repositories or downloaded (tagged) archives.

I am not familiar enough with autotools to find a way to [update](https://www.gnu.org/savannah-checkouts/gnu/autoconf/manual/autoconf-2.69/html_node/Initializing-configure.html) `AC_INIT` reliably with information from git, so I used the Makefile approach that I know.

Output when building on a tagged commit (I tagged `0.2` locally):

    $ ./slirp4netns --version
    slirp4netns version 0.2
    commit: d0a29c32897a012c40bd1d618f96d5b7763ce70c

Output when building a few commits after a tagged commit:

    $ ./slirp4netns --version
    slirp4netns version 0.2.r1
    commit: 52c50e5ccac7eabd3a0cb5af14989d00dfe18a65

