### PR TITLE
fix non-1500 MTU

### DIFF
--- a/qemu/slirp/slirp.c
+++ b/qemu/slirp/slirp.c
@@ -951,7 +951,7 @@ static int if_encap6(Slirp *slirp, struct mbuf *ifm, struct ethhdr *eh,
  */
 int if_encap(Slirp *slirp, struct mbuf *ifm)
 {
-    uint8_t buf[1600];
+    uint8_t buf[65521 + 100]; // max MTU + 100
     struct ethhdr *eh = (struct ethhdr *)buf;
     uint8_t ethaddr[ETH_ALEN];
     const struct ip *iph = (const struct ip *)ifm->m_data;

--- a/qemu/slirp/tcp.h
+++ b/qemu/slirp/tcp.h
@@ -96,19 +96,6 @@ struct tcphdr {
 #define    TCPOLEN_TSTAMP_APPA		(TCPOLEN_TIMESTAMP+2) /* appendix A */
 #endif
 
-/*
- * Default maximum segment size for TCP.
- * With an IP MSS of 576, this is 536,
- * but 512 is probably more convenient.
- * This should be defined as MIN(512, IP_MSS - sizeof (struct tcpiphdr)).
- *
- * We make this 1460 because we only care about Ethernet in the qemu context.
- */
-#undef TCP_MSS
-#define	TCP_MSS	1460
-#undef TCP6_MSS
-#define TCP6_MSS 1440
-
 #undef TCP_MAXWIN
 #define	TCP_MAXWIN	65535	/* largest value for (unscaled) window */
 

--- a/qemu/slirp/tcp_subr.c
+++ b/qemu/slirp/tcp_subr.c
@@ -262,7 +262,7 @@ tcp_newtcpcb(struct socket *so)
 
 	memset((char *) tp, 0, sizeof(struct tcpcb));
 	tp->seg_next = tp->seg_prev = (struct tcpiphdr*)tp;
-	tp->t_maxseg = (so->so_ffamily == AF_INET) ? TCP_MSS : TCP6_MSS;
+	tp->t_maxseg = so->slirp->if_mtu - ((so->so_ffamily == AF_INET) ? 40 : 60);
 
 	tp->t_flags = TCP_DO_RFC1323 ? (TF_REQ_SCALE|TF_REQ_TSTMP) : 0;
 	tp->t_socket = so;


### PR DESCRIPTION
Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>

Cherry-picked from #29

Without the change in `if_encap` (`buf[1600]` -> `buf[65521 + 100]`), #29 stops working immediately with MTU >= 1587.
