### PR TITLE
[WIP/DNM] man: add example iptables rules for protecting 127.0.0.1 on the host

### DIFF
--- a/slirp4netns.1
+++ b/slirp4netns.1
@@ -27,7 +27,7 @@ Gateway: 10.0.2.2, fd00::2
 .IP \(bu 2
 DNS: 10.0.2.3, fd00::3
 .IP \(bu 2
-Host: 10.0.2.2, 10.0.2.3, fd00::2, fd00::3
+Host: 10.0.2.2, 10.0.2.3, fd00::2, fd00::3 (See \fBFILTERING CONNECTIONS\fP)
 
 .RE
 
@@ -157,6 +157,31 @@ e.g.
 
 .nf
 $ sudo sh \-c "echo 0   2147483647  > /proc/sys/net/ipv4/ping\_group\_range"
+
+.fi
+.RE
+
+
+.SH FILTERING CONNECTIONS
+.PP
+By default, ports listening on the host loopback address (127.0.0.1, ::1) are
+accessible from the child namespace via 10.0.2.2, 10.0.2.3, fd00::2, and
+fd00::3.
+
+.PP
+It is recommended to configure iptables rules to block connections to these
+addresses.
+
+.PP
+e.g.
+
+.PP
+.RS
+
+.nf
+unshared$ iptables \-A OUTPUT \-d 10.0.2.2 \-j DROP
+unshared$ iptables \-A OUTPUT \-d 10.0.2.3 \-p udp \-\-dport 53 \-j ACCEPT
+unshared$ iptables \-A OUTPUT \-d 10.0.2.3 \-j DROP
 
 .fi
 .RE

--- a/slirp4netns.1.md
+++ b/slirp4netns.1.md
@@ -19,7 +19,7 @@ Default configuration:
 
 * Gateway: 10.0.2.2, fd00::2
 * DNS: 10.0.2.3, fd00::3
-* Host: 10.0.2.2, 10.0.2.3, fd00::2, fd00::3
+* Host: 10.0.2.2, 10.0.2.3, fd00::2, fd00::3 (See **FILTERING CONNECTIONS**)
 
 # OPTIONS
 
@@ -106,6 +106,22 @@ as the root.
 e.g.
 ```console
 $ sudo sh -c "echo 0   2147483647  > /proc/sys/net/ipv4/ping_group_range"
+```
+
+# FILTERING CONNECTIONS
+
+By default, ports listening on the host loopback address (127.0.0.1, ::1) are
+accessible from the child namespace via 10.0.2.2, 10.0.2.3, fd00::2, and
+fd00::3.
+
+It is recommended to configure iptables rules to block connections to these
+addresses.
+
+e.g.
+```console
+unshared$ iptables -A OUTPUT -d 10.0.2.2 -j DROP
+unshared$ iptables -A OUTPUT -d 10.0.2.3 -p udp --dport 53 -j ACCEPT
+unshared$ iptables -A OUTPUT -d 10.0.2.3 -j DROP
 ```
 
 # SEE ALSO


### PR DESCRIPTION
Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>

WIP/DNM: the current rule does not work with port API #29 