### PR TITLE
[security enhancement] add --no-host-loopback

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -5,7 +5,7 @@ AM_CFLAGS = -I $(abs_top_srcdir)/rd235_libslirp/include -I$(abs_top_srcdir)/rd23
 noinst_LIBRARIES = libqemu_slirp.a libslirp.a libparson.a
 
 AM_TESTS_ENVIRONMENT = PATH="$(abs_top_builddir):$(PATH)"
-TESTS = tests/test-slirp4netns.sh tests/test-slirp4netns-configure.sh tests/test-slirp4netns-exit-fd.sh tests/test-slirp4netns-ready-fd.sh tests/test-slirp4netns-api-socket.sh
+TESTS = tests/test-slirp4netns.sh tests/test-slirp4netns-configure.sh tests/test-slirp4netns-exit-fd.sh tests/test-slirp4netns-ready-fd.sh tests/test-slirp4netns-api-socket.sh tests/test-slirp4netns-no-host-loopback.sh
 
 EXTRA_DIST = \
 	slirp4netns.1.md \
@@ -38,6 +38,7 @@ EXTRA_DIST = \
 	qemu/slirp/tcpip.h \
 	rd235_libslirp/include/qemu/osdep.h \
 	rd235_libslirp/src/qemu2libslirp.h \
+	rd235_libslirp/src/qemu2libslirp-bool.h \
 	parson/parson.h
 
 libqemu_slirp_a_SOURCES = \

--- a/qemu/README.md
+++ b/qemu/README.md
@@ -1,3 +1,5 @@
 # slirp4netns/qemu
 
 The files under this directory are forked from QEMU v3.0.0-rc0: https://github.com/qemu/qemu/commit/c447afd5783b9237fa51b7a85777007d8d568bfc
+
+See `git grep "Changed from QEMU"` for notable changes from the QEMU upstream.

--- a/qemu/slirp/ip_icmp.c
+++ b/qemu/slirp/ip_icmp.c
@@ -183,7 +183,10 @@ icmp_input(struct mbuf *m, int hlen)
 
       /* Send the packet */
       addr = so->fhost.ss;
-      sotranslate_out(so, &addr);
+      if (sotranslate_out(so, &addr) < 0) {
+        icmp_send_error(m, ICMP_UNREACH, ICMP_UNREACH_NET, 0, strerror(errno));
+        udp_detach(so);
+      }
 
       if(sendto(so->s, icmp_ping_msg, strlen(icmp_ping_msg), 0,
 		(struct sockaddr *)&addr, sockaddr_size(&addr)) == -1) {

--- a/qemu/slirp/libslirp.h
+++ b/qemu/slirp/libslirp.h
@@ -16,6 +16,7 @@ Slirp *slirp_init(int restricted, bool in_enabled, struct in_addr vnetwork,
                   struct in_addr vdhcp_start, struct in_addr vnameserver,
                   struct in6_addr vnameserver6, const char **vdnssearch,
                   const char *vdomainname, unsigned int if_mtu, unsigned int if_mru,
+                  bool no_host_loopback,
                   void *opaque);
 void slirp_cleanup(Slirp *slirp);
 

--- a/qemu/slirp/slirp.c
+++ b/qemu/slirp/slirp.c
@@ -272,7 +272,8 @@ Slirp *slirp_init(int restricted, bool in_enabled, struct in_addr vnetwork,
                   const char *bootfile,
                   struct in_addr vdhcp_start, struct in_addr vnameserver,
                   struct in6_addr vnameserver6, const char **vdnssearch,
-                  const char *vdomainname, unsigned int if_mtu, unsigned int if_mru, void *opaque)
+                  const char *vdomainname, unsigned int if_mtu, unsigned int if_mru,
+                  bool no_host_loopback, void *opaque)
 {
     Slirp *slirp = g_malloc0(sizeof(Slirp));
 
@@ -313,6 +314,7 @@ Slirp *slirp_init(int restricted, bool in_enabled, struct in_addr vnetwork,
 
     slirp->if_mtu = if_mtu == 0 ? 1500 : if_mtu;
     slirp->if_mru = if_mru == 0 ? 1500 : if_mru;
+    slirp->no_host_loopback = no_host_loopback;
     slirp->opaque = opaque;
 
     QTAILQ_INSERT_TAIL(&slirp_instances, slirp, entry);

--- a/qemu/slirp/slirp.h
+++ b/qemu/slirp/slirp.h
@@ -1,6 +1,7 @@
 #ifndef SLIRP_H
 #define SLIRP_H
 
+#include <qemu2libslirp-bool.h>
 #include <qemu2libslirp.h>
 
 #include "slirp_config.h"
@@ -176,6 +177,10 @@ struct Slirp {
     /* Changed from QEMU: IF_MTU and IF_MRU were originally hard-coded to 1500 in if.h */
     int if_mtu;
     int if_mru;
+
+
+    /* Changed from QEMU: no_host_loopback is added for prohibiting connections to 127.0.0.1 */
+    bool no_host_loopback;
 
     /* mbuf states */
     struct quehead m_freelist;

--- a/qemu/slirp/socket.h
+++ b/qemu/slirp/socket.h
@@ -151,7 +151,7 @@ struct iovec; /* For win32 */
 size_t sopreprbuf(struct socket *so, struct iovec *iov, int *np);
 int soreadbuf(struct socket *so, const char *buf, int size);
 
-void sotranslate_out(struct socket *, struct sockaddr_storage *);
+int sotranslate_out(struct socket *, struct sockaddr_storage *);
 void sotranslate_in(struct socket *, struct sockaddr_storage *);
 void sotranslate_accept(struct socket *);
 

--- a/qemu/slirp/tcp_subr.c
+++ b/qemu/slirp/tcp_subr.c
@@ -421,7 +421,8 @@ int tcp_fconnect(struct socket *so, unsigned short af)
 
     addr = so->fhost.ss;
     DEBUG_CALL(" connect()ing")
-    sotranslate_out(so, &addr);
+    if (sotranslate_out(so, &addr) < 0)
+      return -1;
 
     /* We don't care what port we get */
     ret = connect(s, (struct sockaddr *)&addr, sockaddr_size(&addr));

--- a/rd235_libslirp/src/qemu2libslirp-bool.h
+++ b/rd235_libslirp/src/qemu2libslirp-bool.h
@@ -1,0 +1,8 @@
+#ifndef QEMU2SLIRPLIB_BOOL_H
+#define QEMU2SLIRPLIB_BOOL_H
+
+/* TODO: switch to stdbool.h (caution: storage size is different) */
+typedef int bool;
+#define true 1
+#define false 0
+#endif

--- a/rd235_libslirp/src/qemu2libslirp.h
+++ b/rd235_libslirp/src/qemu2libslirp.h
@@ -4,9 +4,6 @@
 #define slirp_send _slirp_send
 
 #define QEMU_PACKED __attribute__((packed))
-typedef int bool;
-#define true 1
-#define false 0
 #include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/slirp4netns.1
+++ b/slirp4netns.1
@@ -50,6 +50,10 @@ specify the FD to write to when the network is configured.
 specify MTU (default=1500, max=65521).
 
 .PP
+\fB\-\-no\-host\-loopback\fP
+prohibit connecting to 127.0.0.1:* on the host namespace
+
+.PP
 \fB\-a\fP, \fB\-\-api\-socket\fP
 API socket path (experimental).
 
@@ -161,6 +165,26 @@ e.g.
 
 .nf
 $ sudo sh \-c "echo 0   2147483647  > /proc/sys/net/ipv4/ping\_group\_range"
+
+.fi
+.RE
+
+
+.SH FILTERING CONNECTIONS
+.PP
+By default, ports listening on \fBINADDR\_LOOPBACK\fP (\fB127.0.0.1\fP) on the host are accessible from the child namespace via \fB10.0.2.2\fP\&.
+\fB\-\-no\-host\-loopback\fP can be used to prohibit connecting to \fBINADDR\_LOOPBACK\fP on the host.
+
+.PP
+However, a host loopback address might be still accessible via \fB10.0.2.3\fP if \fB\fC/etc/resolv.conf\fR on the host refers to a loopback address.
+You may want to set up iptables for limiting access to \fB10.0.2.3\fP in such a case.
+
+.PP
+.RS
+
+.nf
+unshared$ iptables \-A OUTPUT \-d 10.0.2.3 \-p udp \-\-dport 53 \-j ACCEPT
+unshared$ iptables \-A OUTPUT \-d 10.0.2.3 \-j DROP
 
 .fi
 .RE

--- a/slirp4netns.1.md
+++ b/slirp4netns.1.md
@@ -35,6 +35,9 @@ specify the FD to write to when the network is configured.
 **-m**, **--mtu=MTU**
 specify MTU (default=1500, max=65521).
 
+**--no-host-loopback**
+prohibit connecting to 127.0.0.1:\* on the host namespace
+
 **-a**, **--api-socket**
 API socket path (experimental).
 
@@ -109,6 +112,19 @@ as the root.
 e.g.
 ```console
 $ sudo sh -c "echo 0   2147483647  > /proc/sys/net/ipv4/ping_group_range"
+```
+
+# FILTERING CONNECTIONS
+
+By default, ports listening on **INADDR_LOOPBACK** (**127.0.0.1**) on the host are accessible from the child namespace via **10.0.2.2**.
+**--no-host-loopback** can be used to prohibit connecting to **INADDR_LOOPBACK** on the host.
+
+However, a host loopback address might be still accessible via **10.0.2.3** if `/etc/resolv.conf` on the host refers to a loopback address.
+You may want to set up iptables for limiting access to **10.0.2.3** in such a case.
+
+```console
+unshared$ iptables -A OUTPUT -d 10.0.2.3 -p udp --dport 53 -j ACCEPT
+unshared$ iptables -A OUTPUT -d 10.0.2.3 -j DROP
 ```
 
 # API SOCKET (EXPERIMENTAL)

--- a/slirp4netns.h
+++ b/slirp4netns.h
@@ -1,6 +1,11 @@
-#ifndef SLIRP_H
-# define SLIRP_H
+#ifndef SLIRP4NETNS_H
+# define SLIRP4NETNS_H
 
-int do_slirp(int tapfd, int exitfd, unsigned int mtu, const char *api_socket, bool enable_ipv6);
+struct slirp_config {
+	unsigned int mtu;
+	bool enable_ipv6;
+	bool no_host_loopback;
+};
+int do_slirp(int tapfd, int exitfd, const char *api_socket, struct slirp_config *cfg);
 
 #endif

--- a/tests/test-slirp4netns-no-host-loopback.sh
+++ b/tests/test-slirp4netns-no-host-loopback.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -xeuo pipefail
+
+. $(dirname $0)/../tests/common.sh
+
+port=12121
+nc -l 127.0.0.1 $port &
+nc_pid=$!
+
+unshare -r -n sleep infinity &
+child=$!
+
+wait_for_network_namespace $child
+
+mtu=${MTU:=1500}
+slirp4netns -c --mtu $mtu --no-host-loopback $child tun11 &
+slirp_pid=$!
+
+wait_for_network_device $child tun11
+# ping to 10.0.2.2 is possible even with --no-host-loopback
+wait_for_ping_connectivity $child 10.0.2.2
+
+function cleanup {
+    kill -9 $nc_pid $child $slirp_pid
+}
+trap cleanup EXIT
+
+set +e
+err=$(echo "should fail" | nsenter --preserve-credentials -U -n --target=$child nc -v 10.0.2.2 $port 2>&1)
+set -e
+echo $err | grep "Network is unreachable"
+


### PR DESCRIPTION
By default, ports listening on INADDR_LOOPBACK (127.0.0.1) on the host are
accessible from the child namespace via 10.0.2.2.

A new option --no-host-loopback can be used to prohibit connecting to
INADDR_LOOPBACK on the host.

Fix #11 

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>