### PR TITLE
Release v0.2.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.69])
-AC_INIT([slirp4netns], [0.2.0], [https://github.com/rootless-containers/slirp4netns/issues])
+AC_INIT([slirp4netns], [0.2.0+dev], [https://github.com/rootless-containers/slirp4netns/issues])
 AC_CONFIG_SRCDIR([main.c])
 AC_CONFIG_HEADERS([config.h])
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.69])
-AC_INIT([slirp4netns], [0.1], [https://github.com/rootless-containers/slirp4netns/issues])
+AC_INIT([slirp4netns], [0.2.0], [https://github.com/rootless-containers/slirp4netns/issues])
 AC_CONFIG_SRCDIR([main.c])
 AC_CONFIG_HEADERS([config.h])
 


### PR DESCRIPTION
This PR bumps up the hard-coded version string in `configure.ac`. ("v0.2.0" for tagging `v0.2.0`, "v0.2.0+dev" for the next version development)

The PR is a temporary workaround until the discussion on #44 and #45 settles.