### PR TITLE
RFC: hostfwd as argument

### DIFF
--- a/api.h
+++ b/api.h
@@ -5,5 +5,6 @@ struct api_ctx;
 struct slirp_config;
 struct api_ctx *api_ctx_alloc(struct slirp_config *cfg);
 void api_ctx_free(struct api_ctx *ctx);
+int api_add_to_list(struct api_ctx *ctx, bool is_udp, struct in_addr hostaddr, int hostport, struct in_addr guestaddr, int guestport);
 int api_handler(Slirp * slirp, int listenfd, struct api_ctx *ctx);
 #endif

--- a/slirp4netns.h
+++ b/slirp4netns.h
@@ -2,6 +2,14 @@
 # define SLIRP4NETNS_H
 #include <arpa/inet.h>
 
+struct hostfwd_t {
+	bool is_udp;
+	struct in_addr hostaddr;
+	uint16_t hostport;
+	struct in_addr guestaddr;
+	uint16_t guestport;
+};
+
 struct slirp_config {
 	unsigned int mtu;
 	struct in_addr vnetwork; // 10.0.2.0
@@ -11,6 +19,8 @@ struct slirp_config {
 	struct in_addr vnameserver; // 10.0.2.3
 	struct in_addr recommended_vguest; // 10.0.2.100 (slirp itself is unaware of vguest)
 	bool enable_ipv6;
+	int hostfwd_count;
+	struct hostfwd_t *forwards;
 	bool disable_host_loopback;
 };
 int do_slirp(int tapfd, int exitfd, const char *api_socket, struct slirp_config *cfg);


### PR DESCRIPTION
Hi All,

as discussed in the api pull request, I added the hostfwd option also as an argument, so that clients don't need to support json handling for basic use cases.

This is still rough, and my C foo is also no longer in it's highest state, so comments are more than welcome.

Regards,
David

Usage:
unshare --user --map-root-user --net --mount
echo $$ > /tmp/pid
./slirp4netns --configure --mtu=65520 $(cat /tmp/pid) -f ::1234-:80 tap0

In unshare:
nc -l 10.0.2.100 80

Outside unshare:
nc localhost 1234