### PR TITLE
replace `typedef int bool` with stdbool.h

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -38,7 +38,6 @@ EXTRA_DIST = \
 	qemu/slirp/tcpip.h \
 	rd235_libslirp/include/qemu/osdep.h \
 	rd235_libslirp/src/qemu2libslirp.h \
-	rd235_libslirp/src/qemu2libslirp-bool.h \
 	parson/parson.h
 
 libqemu_slirp_a_SOURCES = \

--- a/main.c
+++ b/main.c
@@ -16,7 +16,7 @@
 #include <net/if.h>
 #include <net/route.h>
 #include <getopt.h>
-#include <qemu2libslirp-bool.h>
+#include <stdbool.h>
 #include "slirp4netns.h"
 
 static int nsenter(pid_t target_pid)

--- a/qemu/slirp/slirp.h
+++ b/qemu/slirp/slirp.h
@@ -1,7 +1,7 @@
 #ifndef SLIRP_H
 #define SLIRP_H
 
-#include <qemu2libslirp-bool.h>
+#include <stdbool.h>
 #include <qemu2libslirp.h>
 
 #include "slirp_config.h"

--- a/rd235_libslirp/src/qemu2libslirp-bool.h
+++ b/rd235_libslirp/src/qemu2libslirp-bool.h
@@ -1,8 +1,0 @@
-#ifndef QEMU2SLIRPLIB_BOOL_H
-#define QEMU2SLIRPLIB_BOOL_H
-
-/* TODO: switch to stdbool.h (caution: storage size is different) */
-typedef int bool;
-#define true 1
-#define false 0
-#endif


### PR DESCRIPTION
Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>