### PR TITLE
Release v0.3.0-alpha.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.69])
-AC_INIT([slirp4netns], [0.2.0+dev], [https://github.com/rootless-containers/slirp4netns/issues])
+AC_INIT([slirp4netns], [0.3.0-alpha.0], [https://github.com/rootless-containers/slirp4netns/issues])
 AC_CONFIG_SRCDIR([main.c])
 AC_CONFIG_HEADERS([config.h])
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.69])
-AC_INIT([slirp4netns], [0.3.0-alpha.0], [https://github.com/rootless-containers/slirp4netns/issues])
+AC_INIT([slirp4netns], [0.3.0-alpha.0+dev], [https://github.com/rootless-containers/slirp4netns/issues])
 AC_CONFIG_SRCDIR([main.c])
 AC_CONFIG_HEADERS([config.h])
 

--- a/slirp4netns.1
+++ b/slirp4netns.1
@@ -70,7 +70,7 @@ prohibit connecting to 127.0.0.1:* on the host namespace
 API socket path (experimental).
 
 .PP
-\fB\-6\fP, \fB\-\-enable\-ipv6\fP (since v0.3.0)
+\fB\-6\fP, \fB\-\-enable\-ipv6\fP
 enable IPv6 (experimental).
 
 .PP

--- a/slirp4netns.1.md
+++ b/slirp4netns.1.md
@@ -48,7 +48,7 @@ prohibit connecting to 127.0.0.1:\* on the host namespace
 **-a**, **--api-socket** (since v0.3.0)
 API socket path (experimental).
 
-**-6**, **--enable-ipv6** (since v0.3.0)
+**-6**, **--enable-ipv6**
 enable IPv6 (experimental).
 
 **-h**, **--help**


### PR DESCRIPTION
Notable changes since v0.2.0:
* [EXPERIMENTAL] QMP-like JSON API for exposing node ports (`--api-socket`) (#29)
*  Support protecting 127.0.0.1 on the host (`--disable-host-loopback`) (#50, #63)
* Support specifying CIDR like `10.0.2.0/24`(`--cidr`) (#62)