### PR TITLE
v0.3.0-beta.0

### DIFF
--- a/api.c
+++ b/api.c
@@ -1,5 +1,6 @@
 #define _GNU_SOURCE
 #include <stdio.h>
+#include <stdlib.h>
 #include <unistd.h>
 #include <sys/un.h>
 #include <glib.h>

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.69])
-AC_INIT([slirp4netns], [0.3.0-alpha.2+dev], [https://github.com/rootless-containers/slirp4netns/issues])
+AC_INIT([slirp4netns], [0.3.0-beta.0], [https://github.com/rootless-containers/slirp4netns/issues])
 AC_CONFIG_SRCDIR([main.c])
 AC_CONFIG_HEADERS([config.h])
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.69])
-AC_INIT([slirp4netns], [0.3.0-beta.0], [https://github.com/rootless-containers/slirp4netns/issues])
+AC_INIT([slirp4netns], [0.3.0-beta.0+dev], [https://github.com/rootless-containers/slirp4netns/issues])
 AC_CONFIG_SRCDIR([main.c])
 AC_CONFIG_HEADERS([config.h])
 


### PR DESCRIPTION
Changes since alpha 2:
#72 update docs 
#73 sync with qemu upstream (**NEW BUILD DEPENDENCY**: `glib2-devel` (`libglib2.0-dev`))

cc @rootless-containers/slirp4netns-package-maintainers FYI
