### PR TITLE
MAINTAINERS: update Akihiro Suda's email address

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -73,7 +73,7 @@
 [people]
 	[people.akihirosuda]
 	Name = "Akihiro Suda"
-	Email = "suda.akihiro@lab.ntt.co.jp"
+	Email = "akihiro.suda.cz@hco.ntt.co.jp"
 	GitHub = "AkihiroSuda"
 
 	[people.barthalion]

--- a/qemu/README.md
+++ b/qemu/README.md
@@ -3,9 +3,9 @@
 This directory was synced from QEMU `49fc899f8d673dd9e73f3db0d9e9ea60b77c331b` (`https://github.com/qemu/qemu.git`),
 with the following patches (sha256sum):
 ```
-6bed7e4f10c4d462a84656b08441a740fb86c31a0b5394e4c89c06f6a8f44827  0001-slirp-add-slirp_initx-SlirpConfig-SlirpCb-void.patch
-ec3aaabaee978867456e245eaa2353e43dbdb64e1a4dbd5a1b6070176dfd581f  0002-slirp-allow-custom-MTU.patch
-a55b85550b07be4f99710ff6e9baa63294a33924f275c5be18f771736a9dcc56  0003-slirp-add-disable_host_loopback-prohibit-connections.patch
+c0b2156997b9680e37388d3e01c730bb130f2ba65b7b20be7c1d77819dda2f24  0001-slirp-add-slirp_initx-SlirpConfig-SlirpCb-void.patch
+564e0e4e15e3a1b59389e23092ba30e3d4f2cf2c9422c7ac1ccfd88d16ef69c6  0002-slirp-allow-custom-MTU.patch
+18dfef203edcd4cde68bf7e78e4e3401adaa2cd3f7bf7425432666f760f95c33  0003-slirp-add-disable_host_loopback-prohibit-connections.patch
 ```
 
 Please do not edit the contents under this directory manually.

--- a/qemu_patches/0001-slirp-add-slirp_initx-SlirpConfig-SlirpCb-void.patch
+++ b/qemu_patches/0001-slirp-add-slirp_initx-SlirpConfig-SlirpCb-void.patch
@@ -1,19 +1,19 @@
-From 4d374172b307a131ebe7f4ce39035d7713eca937 Mon Sep 17 00:00:00 2001
-From: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>
+From 9e08043c303089f211a9f1e522c84f9235e643f7 Mon Sep 17 00:00:00 2001
+From: Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp>
 Date: Wed, 6 Mar 2019 16:07:23 +0900
 Subject: [PATCH 1/3] slirp: add slirp_initx(SlirpConfig *, SlirpCb *, void *)
 
-Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>
+Signed-off-by: Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp>
 ---
  slirp/src/libslirp.h | 24 ++++++++++-
  slirp/src/slirp.c    | 97 ++++++++++++++++++++++++++++----------------
  2 files changed, 86 insertions(+), 35 deletions(-)
 
 diff --git a/slirp/src/libslirp.h b/slirp/src/libslirp.h
-index 2d13950065..a82c3fca38 100644
+index 3b28764bec..bd141964ff 100644
 --- a/slirp/src/libslirp.h
 +++ b/slirp/src/libslirp.h
-@@ -63,7 +63,29 @@ typedef struct SlirpCb {
+@@ -64,7 +64,29 @@ typedef struct SlirpCb {
      void (*notify)(void *opaque);
  } SlirpCb;
  
@@ -45,10 +45,10 @@ index 2d13950065..a82c3fca38 100644
                    struct in_addr vnetmask, struct in_addr vhost,
                    bool in6_enabled,
 diff --git a/slirp/src/slirp.c b/slirp/src/slirp.c
-index 18af670a0a..a76e33f44c 100644
+index 169c85b906..ee5833e18b 100644
 --- a/slirp/src/slirp.c
 +++ b/slirp/src/slirp.c
-@@ -269,30 +269,23 @@ static void slirp_init_once(void)
+@@ -270,30 +270,23 @@ static void slirp_init_once(void)
  
  }
  
@@ -88,7 +88,7 @@ index 18af670a0a..a76e33f44c 100644
  
      if_init(slirp);
      ip_init(slirp);
-@@ -301,31 +294,67 @@ Slirp *slirp_init(int restricted, bool in_enabled, struct in_addr vnetwork,
+@@ -302,31 +295,67 @@ Slirp *slirp_init(int restricted, bool in_enabled, struct in_addr vnetwork,
      /* Initialise mbufs *after* setting the MTU */
      m_init(slirp);
  

--- a/qemu_patches/0002-slirp-allow-custom-MTU.patch
+++ b/qemu_patches/0002-slirp-allow-custom-MTU.patch
@@ -1,5 +1,5 @@
-From fc1f39e37bc3c4287098f52a17a6cb35ad7c5f33 Mon Sep 17 00:00:00 2001
-From: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>
+From b257a4a3a602786a44e38b4de88e1c9c0227590e Mon Sep 17 00:00:00 2001
+From: Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp>
 Date: Wed, 6 Mar 2019 16:15:37 +0900
 Subject: [PATCH 2/3] slirp: allow custom MTU
 
@@ -10,7 +10,7 @@ From slirp4netns project:
 * https://github.com/rootless-containers/slirp4netns/commit/a11abedafcc627ef0657999e63b211b0f26d4c02
 * https://github.com/rootless-containers/slirp4netns/commit/2adbd7c449944d3b837164c86eedd3dcabbba1a6
 
-Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>
+Signed-off-by: Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp>
 ---
  slirp/src/dhcpv6.c    |  2 +-
  slirp/src/if.h        |  6 ++++--
@@ -27,10 +27,10 @@ Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>
  12 files changed, 38 insertions(+), 32 deletions(-)
 
 diff --git a/slirp/src/dhcpv6.c b/slirp/src/dhcpv6.c
-index e655c7d5b1..3a1b4fcb30 100644
+index 3c8f420912..53bb90b541 100644
 --- a/slirp/src/dhcpv6.c
 +++ b/slirp/src/dhcpv6.c
-@@ -159,7 +159,7 @@ static void dhcpv6_info_request(Slirp *slirp, struct sockaddr_in6 *srcsas,
+@@ -177,7 +177,7 @@ static void dhcpv6_info_request(Slirp *slirp, struct sockaddr_in6 *srcsas,
  
          *resp++ = OPTION_BOOTFILE_URL >> 8;     /* option-code high byte */
          *resp++ = OPTION_BOOTFILE_URL;          /* option-code low byte */
@@ -40,10 +40,10 @@ index e655c7d5b1..3a1b4fcb30 100644
                          "tftp://[%02x%02x:%02x%02x:%02x%02x:%02x%02x:"
                                  "%02x%02x:%02x%02x:%02x%02x:%02x%02x]/%s",
 diff --git a/slirp/src/if.h b/slirp/src/if.h
-index 69569c10df..4bbb9c75f8 100644
+index b71c37d6ea..7a47a12ab2 100644
 --- a/slirp/src/if.h
 +++ b/slirp/src/if.h
-@@ -13,8 +13,10 @@
+@@ -11,8 +11,10 @@
  #define IF_AUTOCOMP	0x04	/* Autodetect (default) */
  #define IF_NOCIDCOMP	0x08	/* CID compression */
  
@@ -57,10 +57,10 @@ index 69569c10df..4bbb9c75f8 100644
  
  /* 2 for alignment, 14 for ethernet */
 diff --git a/slirp/src/ip6_icmp.c b/slirp/src/ip6_icmp.c
-index c1e3d30470..5e0af223eb 100644
+index 5642457fdd..dcace933a9 100644
 --- a/slirp/src/ip6_icmp.c
 +++ b/slirp/src/ip6_icmp.c
-@@ -92,7 +92,7 @@ void icmp6_send_error(struct mbuf *m, uint8_t type, uint8_t code)
+@@ -93,7 +93,7 @@ void icmp6_send_error(struct mbuf *m, uint8_t type, uint8_t code)
  
      rip->ip_nh = IPPROTO_ICMPV6;
      const int error_data_len = MIN(m->m_len,
@@ -69,7 +69,7 @@ index c1e3d30470..5e0af223eb 100644
      rip->ip_pl = htons(ICMP6_ERROR_MINLEN + error_data_len);
      t->m_len = sizeof(struct ip6) + ntohs(rip->ip_pl);
  
-@@ -109,7 +109,7 @@ void icmp6_send_error(struct mbuf *m, uint8_t type, uint8_t code)
+@@ -110,7 +110,7 @@ void icmp6_send_error(struct mbuf *m, uint8_t type, uint8_t code)
          ricmp->icmp6_err.unused = 0;
          break;
      case ICMP6_TOOBIG:
@@ -79,10 +79,10 @@ index c1e3d30470..5e0af223eb 100644
      case ICMP6_PARAMPROB:
          /* TODO: Handle this case */
 diff --git a/slirp/src/ip6_input.c b/slirp/src/ip6_input.c
-index 1b8c003c66..917580c0e1 100644
+index d9d2b7e9cd..dfcbfd6a78 100644
 --- a/slirp/src/ip6_input.c
 +++ b/slirp/src/ip6_input.c
-@@ -43,7 +43,7 @@ void ip6_input(struct mbuf *m)
+@@ -44,7 +44,7 @@ void ip6_input(struct mbuf *m)
          goto bad;
      }
  
@@ -92,10 +92,10 @@ index 1b8c003c66..917580c0e1 100644
          goto bad;
      }
 diff --git a/slirp/src/ip_output.c b/slirp/src/ip_output.c
-index f6ec141df5..d342bff6ff 100644
+index 8560197cf6..cd2ea7c72d 100644
 --- a/slirp/src/ip_output.c
 +++ b/slirp/src/ip_output.c
-@@ -75,7 +75,7 @@ ip_output(struct socket *so, struct mbuf *m0)
+@@ -73,7 +73,7 @@ ip_output(struct socket *so, struct mbuf *m0)
  	/*
  	 * If small enough for interface, can just send directly.
  	 */
@@ -104,7 +104,7 @@ index f6ec141df5..d342bff6ff 100644
  		ip->ip_len = htons((uint16_t)ip->ip_len);
  		ip->ip_off = htons((uint16_t)ip->ip_off);
  		ip->ip_sum = 0;
-@@ -94,7 +94,7 @@ ip_output(struct socket *so, struct mbuf *m0)
+@@ -92,7 +92,7 @@ ip_output(struct socket *so, struct mbuf *m0)
  		goto bad;
  	}
  
@@ -114,10 +114,10 @@ index f6ec141df5..d342bff6ff 100644
  		error = -1;
  		goto bad;
 diff --git a/slirp/src/libslirp.h b/slirp/src/libslirp.h
-index a82c3fca38..ecbf0cc4a1 100644
+index bd141964ff..4e2d4ee6c7 100644
 --- a/slirp/src/libslirp.h
 +++ b/slirp/src/libslirp.h
-@@ -82,6 +82,10 @@ typedef struct SlirpConfig{
+@@ -83,6 +83,10 @@ typedef struct SlirpConfig{
      struct in6_addr vnameserver6;
      const char **vdnssearch;
      const char *vdomainname;
@@ -129,10 +129,10 @@ index a82c3fca38..ecbf0cc4a1 100644
  
  Slirp *slirp_initx(const SlirpConfig *cfg, const SlirpCb *callbacks, void *opaque);
 diff --git a/slirp/src/mbuf.c b/slirp/src/mbuf.c
-index 521c02c967..7a8f039559 100644
+index 800406ca9e..b1ac229b7b 100644
 --- a/slirp/src/mbuf.c
 +++ b/slirp/src/mbuf.c
-@@ -22,8 +22,8 @@
+@@ -20,8 +20,8 @@
  /*
   * Find a nice value for msize
   */
@@ -143,7 +143,7 @@ index 521c02c967..7a8f039559 100644
  
  void
  m_init(Slirp *slirp)
-@@ -70,7 +70,7 @@ m_get(Slirp *slirp)
+@@ -68,7 +68,7 @@ m_get(Slirp *slirp)
  	DEBUG_CALL("m_get");
  
  	if (slirp->m_freelist.qh_link == &slirp->m_freelist) {
@@ -152,7 +152,7 @@ index 521c02c967..7a8f039559 100644
  		slirp->mbuf_alloced++;
  		if (slirp->mbuf_alloced > MBUF_THRESH)
  			flags = M_DOFREE;
-@@ -85,7 +85,7 @@ m_get(Slirp *slirp)
+@@ -83,7 +83,7 @@ m_get(Slirp *slirp)
  	m->m_flags = (flags | M_USEDLIST);
  
  	/* Initialise it */
@@ -162,10 +162,10 @@ index 521c02c967..7a8f039559 100644
  	m->m_len = 0;
          m->m_nextpkt = NULL;
 diff --git a/slirp/src/slirp.c b/slirp/src/slirp.c
-index a76e33f44c..cadc35aff0 100644
+index ee5833e18b..8c02913769 100644
 --- a/slirp/src/slirp.c
 +++ b/slirp/src/slirp.c
-@@ -275,6 +275,13 @@ Slirp *slirp_initx(const SlirpConfig *cfg, const SlirpCb *callbacks, void *opaqu
+@@ -276,6 +276,13 @@ Slirp *slirp_initx(const SlirpConfig *cfg, const SlirpCb *callbacks, void *opaqu
      if (cfg == NULL) {
          return NULL;
      }
@@ -179,7 +179,7 @@ index a76e33f44c..cadc35aff0 100644
      slirp = g_malloc0(sizeof(Slirp));
  
      slirp_init_once();
-@@ -315,6 +322,8 @@ Slirp *slirp_initx(const SlirpConfig *cfg, const SlirpCb *callbacks, void *opaqu
+@@ -316,6 +323,8 @@ Slirp *slirp_initx(const SlirpConfig *cfg, const SlirpCb *callbacks, void *opaqu
      if (cfg->vdnssearch) {
          translate_dnssearch(slirp, cfg->vdnssearch);
      }
@@ -188,7 +188,7 @@ index a76e33f44c..cadc35aff0 100644
  
      return slirp;
  }
-@@ -923,7 +932,7 @@ static int if_encap6(Slirp *slirp, struct mbuf *ifm, struct ethhdr *eh,
+@@ -924,7 +933,7 @@ static int if_encap6(Slirp *slirp, struct mbuf *ifm, struct ethhdr *eh,
   */
  int if_encap(Slirp *slirp, struct mbuf *ifm)
  {
@@ -198,10 +198,10 @@ index a76e33f44c..cadc35aff0 100644
      uint8_t ethaddr[ETH_ALEN];
      const struct ip *iph = (const struct ip *)ifm->m_data;
 diff --git a/slirp/src/slirp.h b/slirp/src/slirp.h
-index 8068ba1d1e..538f1591ef 100644
+index 39580934f3..1c485be36f 100644
 --- a/slirp/src/slirp.h
 +++ b/slirp/src/slirp.h
-@@ -145,6 +145,9 @@ struct Slirp {
+@@ -146,6 +146,9 @@ struct Slirp {
      int restricted;
      struct gfwd_list *guestfwd_list;
  
@@ -212,10 +212,10 @@ index 8068ba1d1e..538f1591ef 100644
      struct quehead m_freelist;
      struct quehead m_usedlist;
 diff --git a/slirp/src/tcp.h b/slirp/src/tcp.h
-index 47aaea6c5b..c854771a44 100644
+index 79d3251bb5..fca5c13db5 100644
 --- a/slirp/src/tcp.h
 +++ b/slirp/src/tcp.h
-@@ -40,8 +40,9 @@ typedef	uint32_t tcp_seq;
+@@ -41,8 +41,9 @@ typedef	uint32_t tcp_seq;
  #define      PR_SLOWHZ       2               /* 2 slow timeouts per second (approx) */
  #define      PR_FASTHZ       5               /* 5 fast timeouts per second (not important) */
  
@@ -227,7 +227,7 @@ index 47aaea6c5b..c854771a44 100644
  
  /*
   * TCP header.
-@@ -98,19 +99,6 @@ struct tcphdr {
+@@ -99,19 +100,6 @@ struct tcphdr {
  #define    TCPOLEN_TSTAMP_APPA		(TCPOLEN_TIMESTAMP+2) /* appendix A */
  #endif
  
@@ -248,10 +248,10 @@ index 47aaea6c5b..c854771a44 100644
  #define	TCP_MAXWIN	65535	/* largest value for (unscaled) window */
  
 diff --git a/slirp/src/tcp_input.c b/slirp/src/tcp_input.c
-index b10477fc57..2e84030b6c 100644
+index 50a1145ec9..14a489e61a 100644
 --- a/slirp/src/tcp_input.c
 +++ b/slirp/src/tcp_input.c
-@@ -1524,11 +1524,11 @@ tcp_mss(struct tcpcb *tp, unsigned offer)
+@@ -1522,11 +1522,11 @@ tcp_mss(struct tcpcb *tp, unsigned offer)
  
  	switch (so->so_ffamily) {
  	case AF_INET:
@@ -265,7 +265,7 @@ index b10477fc57..2e84030b6c 100644
  	                              - sizeof(struct ip6);
  	    break;
  	default:
-@@ -1539,7 +1539,7 @@ tcp_mss(struct tcpcb *tp, unsigned offer)
+@@ -1537,7 +1537,7 @@ tcp_mss(struct tcpcb *tp, unsigned offer)
              mss = MIN(mss, offer);
          mss = MAX(mss, 32);
  	if (mss < tp->t_maxseg || offer != 0)
@@ -275,10 +275,10 @@ index b10477fc57..2e84030b6c 100644
  	tp->snd_cwnd = mss;
  
 diff --git a/slirp/src/tcp_subr.c b/slirp/src/tcp_subr.c
-index 1db59caa89..437a0b3306 100644
+index fde9207b0c..e88e51e39c 100644
 --- a/slirp/src/tcp_subr.c
 +++ b/slirp/src/tcp_subr.c
-@@ -261,7 +261,7 @@ tcp_newtcpcb(struct socket *so)
+@@ -259,7 +259,7 @@ tcp_newtcpcb(struct socket *so)
  
  	memset((char *) tp, 0, sizeof(struct tcpcb));
  	tp->seg_next = tp->seg_prev = (struct tcpiphdr*)tp;

--- a/qemu_patches/0003-slirp-add-disable_host_loopback-prohibit-connections.patch
+++ b/qemu_patches/0003-slirp-add-disable_host_loopback-prohibit-connections.patch
@@ -1,5 +1,5 @@
-From 353c5778d80c8b2583f737df73767f2253d67ca5 Mon Sep 17 00:00:00 2001
-From: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>
+From 6e4be54755a06a2278d93a78a624da65928cdddb Mon Sep 17 00:00:00 2001
+From: Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp>
 Date: Wed, 6 Mar 2019 17:04:14 +0900
 Subject: [PATCH 3/3] slirp: add disable_host_loopback (prohibit connections to
  127.0.0.1)
@@ -8,7 +8,7 @@ From slirp4netns project:
 * https://github.com/rootless-containers/slirp4netns/commit/6325473781bb344c225f54e2d28800fb0619d7ee
 * https://github.com/rootless-containers/slirp4netns/commit/13b24026867d4c30d5d1465ac82e3bb890bf4caa
 
-Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>
+Signed-off-by: Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp>
 ---
  slirp/src/ip_icmp.c  |  5 +++-
  slirp/src/libslirp.h |  2 ++
@@ -20,10 +20,10 @@ Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>
  7 files changed, 52 insertions(+), 32 deletions(-)
 
 diff --git a/slirp/src/ip_icmp.c b/slirp/src/ip_icmp.c
-index 120108f582..89e22dc5b8 100644
+index 1aea18afa7..5a7b9a6324 100644
 --- a/slirp/src/ip_icmp.c
 +++ b/slirp/src/ip_icmp.c
-@@ -188,7 +188,10 @@ icmp_input(struct mbuf *m, int hlen)
+@@ -189,7 +189,10 @@ icmp_input(struct mbuf *m, int hlen)
  
        /* Send the packet */
        addr = so->fhost.ss;
@@ -36,10 +36,10 @@ index 120108f582..89e22dc5b8 100644
        if(sendto(so->s, icmp_ping_msg, strlen(icmp_ping_msg), 0,
  		(struct sockaddr *)&addr, sockaddr_size(&addr)) == -1) {
 diff --git a/slirp/src/libslirp.h b/slirp/src/libslirp.h
-index ecbf0cc4a1..a8aa93980d 100644
+index 4e2d4ee6c7..d8e69828ba 100644
 --- a/slirp/src/libslirp.h
 +++ b/slirp/src/libslirp.h
-@@ -86,6 +86,8 @@ typedef struct SlirpConfig{
+@@ -87,6 +87,8 @@ typedef struct SlirpConfig{
      int if_mtu;
      /* Default: IF_MRU_DEFAULT */
      int if_mru;
@@ -49,10 +49,10 @@ index ecbf0cc4a1..a8aa93980d 100644
  
  Slirp *slirp_initx(const SlirpConfig *cfg, const SlirpCb *callbacks, void *opaque);
 diff --git a/slirp/src/slirp.c b/slirp/src/slirp.c
-index cadc35aff0..8ceb566c89 100644
+index 8c02913769..cc1215d2dd 100644
 --- a/slirp/src/slirp.c
 +++ b/slirp/src/slirp.c
-@@ -324,6 +324,7 @@ Slirp *slirp_initx(const SlirpConfig *cfg, const SlirpCb *callbacks, void *opaqu
+@@ -325,6 +325,7 @@ Slirp *slirp_initx(const SlirpConfig *cfg, const SlirpCb *callbacks, void *opaqu
      }
      slirp->if_mtu = cfg->if_mtu == 0 ? IF_MTU_DEFAULT : cfg->if_mtu;
      slirp->if_mru = cfg->if_mru == 0 ? IF_MRU_DEFAULT : cfg->if_mru;
@@ -61,10 +61,10 @@ index cadc35aff0..8ceb566c89 100644
      return slirp;
  }
 diff --git a/slirp/src/slirp.h b/slirp/src/slirp.h
-index 538f1591ef..cfbaee5172 100644
+index 1c485be36f..fce6583f8a 100644
 --- a/slirp/src/slirp.h
 +++ b/slirp/src/slirp.h
-@@ -148,6 +148,8 @@ struct Slirp {
+@@ -149,6 +149,8 @@ struct Slirp {
      int if_mtu;
      int if_mru;
  
@@ -74,10 +74,10 @@ index 538f1591ef..cfbaee5172 100644
      struct quehead m_freelist;
      struct quehead m_usedlist;
 diff --git a/slirp/src/socket.c b/slirp/src/socket.c
-index f2428a3ae8..62a45589c0 100644
+index 4a3c935e25..be27e523e6 100644
 --- a/slirp/src/socket.c
 +++ b/slirp/src/socket.c
-@@ -661,7 +661,9 @@ sosendto(struct socket *so, struct mbuf *m)
+@@ -659,7 +659,9 @@ sosendto(struct socket *so, struct mbuf *m)
  
  	addr = so->fhost.ss;
  	DEBUG_CALL(" sendto()ing)");
@@ -88,7 +88,7 @@ index f2428a3ae8..62a45589c0 100644
  
  	/* Don't care what port we get */
  	ret = sendto(so->s, m->m_data, m->m_len, 0,
-@@ -827,49 +829,57 @@ sofwdrain(struct socket *so)
+@@ -825,49 +827,57 @@ sofwdrain(struct socket *so)
  /*
   * Translate addr in host addr when it is a virtual address
   */
@@ -175,10 +175,10 @@ index f2428a3ae8..62a45589c0 100644
  
  void sotranslate_in(struct socket *so, struct sockaddr_storage *addr)
 diff --git a/slirp/src/socket.h b/slirp/src/socket.h
-index e4d12cd591..f2ee452b41 100644
+index 25403898cd..791ae9482c 100644
 --- a/slirp/src/socket.h
 +++ b/slirp/src/socket.h
-@@ -153,7 +153,7 @@ struct iovec; /* For win32 */
+@@ -151,7 +151,7 @@ struct iovec; /* For win32 */
  size_t sopreprbuf(struct socket *so, struct iovec *iov, int *np);
  int soreadbuf(struct socket *so, const char *buf, int size);
  
@@ -188,10 +188,10 @@ index e4d12cd591..f2ee452b41 100644
  void sotranslate_accept(struct socket *);
  void sodrop(struct socket *, int num);
 diff --git a/slirp/src/tcp_subr.c b/slirp/src/tcp_subr.c
-index 437a0b3306..234102c904 100644
+index e88e51e39c..4224213c14 100644
 --- a/slirp/src/tcp_subr.c
 +++ b/slirp/src/tcp_subr.c
-@@ -422,7 +422,9 @@ int tcp_fconnect(struct socket *so, unsigned short af)
+@@ -420,7 +420,9 @@ int tcp_fconnect(struct socket *so, unsigned short af)
  
      addr = so->fhost.ss;
      DEBUG_CALL(" connect()ing");


### PR DESCRIPTION
No affiliation change (NTT).

The former email address will continue to be available for the time
being.

For daily communication, I still prefer to use my gmail.com address.

Signed-off-by: Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp>