### PR TITLE
slirp4netns: allow to run without --userns-path

### DIFF
--- a/tests/test-slirp4netns.sh
+++ b/tests/test-slirp4netns.sh
@@ -3,6 +3,8 @@ set -xeuo pipefail
 
 . $(dirname $0)/common.sh
 
+
+# Test --netns-type=pid
 unshare -r -n sleep infinity &
 child=$!
 
@@ -19,5 +21,36 @@ function cleanup {
 trap cleanup EXIT
 
 nsenter --preserve-credentials -U -n --target=$child ip -a netconf | grep tun11
+nsenter --preserve-credentials -U -n --target=$child ip addr show tun11 | grep -v inet
 
+kill -9 $child $slirp_pid
+
+# Test --userns-path= --netns-type=path
+unshare -r -n sleep infinity &
+child=$!
+
+wait_for_network_namespace $child
+
+slirp4netns --userns-path=/proc/$child/ns/user --netns-type=path /proc/$child/ns/net tun11 &
+slirp_pid=$!
+
+wait_for_network_device $child tun11
+
+nsenter --preserve-credentials -U -n --target=$child ip -a netconf | grep tun11
+nsenter --preserve-credentials -U -n --target=$child ip addr show tun11 | grep -v inet
+
+kill -9 $child $slirp_pid
+
+# Test --netns-type=path
+unshare -r -n sleep infinity &
+child=$!
+
+wait_for_network_namespace $child
+
+nsenter --preserve-credentials -U --target=$child slirp4netns --netns-type=path /proc/$child/ns/net tun11 &
+slirp_pid=$!
+
+wait_for_network_device $child tun11
+
+nsenter --preserve-credentials -U -n --target=$child ip -a netconf | grep tun11
 nsenter --preserve-credentials -U -n --target=$child ip addr show tun11 | grep -v inet


### PR DESCRIPTION
it is useful if we are already running inside of a user namespace.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>