### PR TITLE
defer --ready-fd activation until everything is ready

### DIFF
--- a/slirp4netns.1
+++ b/slirp4netns.1
@@ -1,3 +1,4 @@
+.nh
 .TH SLIRP4NETNS 1 "July 2018" "Rootless Containers" "User Commands"
 
 .SH NAME
@@ -19,6 +20,8 @@ Unlike \fBveth\fP(4), slirp4netns does not require the root privileges on the ho
 
 .PP
 Default configuration:
+
+.RS
 .IP \(bu 2
 MTU:               1500
 .IP \(bu 2
@@ -34,6 +37,8 @@ IPv6 Gateway/Host: fd00::2
 .IP \(bu 2
 IPv6 DNS:          fd00::3
 
+.RE
+
 
 .SH OPTIONS
 .PP
@@ -46,7 +51,9 @@ specify the FD for terminating slirp4netns.
 
 .PP
 \fB\-r\fP, \fB\-\-ready\-fd=FD\fP
-specify the FD to write to when the network is configured.
+specify the FD to write to when the initialization steps are finished.
+Prior to v0.4.0, the FD was written after the network configuration (\fB\-c\fP)
+but before the API socket configuration (\fB\-a\fP).
 
 .PP
 \fB\-m\fP, \fB\-\-mtu=MTU\fP
@@ -268,6 +275,8 @@ $ echo \-n $json | nc \-U /tmp/slirp4netns.sock
 
 .PP
 Remarks:
+
+.RS
 .IP \(bu 2
 Client needs to \fBshutdown\fP the socket with \fBSHUT\_WR\fP after sending every request.
 i.e. No support for keep\-alive and timeout.
@@ -277,6 +286,8 @@ slirp4netns "stops the world" during processing API requests.
 A request must be less than 4095 bytes.
 .IP \(bu 2
 JSON responses may contain \fBerror\fP instead of \fBreturn\fP\&.
+
+.RE
 
 
 .SH DEFINED NAMESPACE PATHS
@@ -315,5 +326,4 @@ $ slirp4netns \-\-netns\-type=path \-\-userns\-path=/path/to/userns /path/to/net
 
 .SH AVAILABILITY
 .PP
-The slirp4netns command is available from \fB
-\[la]https://github.com/rootless-containers/slirp4netns\[ra]\fP under GNU GENERAL PUBLIC LICENSE Version 2.
+The slirp4netns command is available from \fBhttps://github.com/rootless\-containers/slirp4netns\fP under GNU GENERAL PUBLIC LICENSE Version 2.

--- a/slirp4netns.1
+++ b/slirp4netns.1
@@ -76,11 +76,11 @@ API socket path
 enable IPv6 (experimental).
 
 .PP
-\fB\-\-netns\-type=TYPE\fP
+\fB\-\-netns\-type=TYPE\fP (since v0.4.0)
 specify network namespace type ([path|pid], default=pid)
 
 .PP
-\fB\-\-userns\-path=PATH\fP
+\fB\-\-userns\-path=PATH\fP (since v0.4.0)
 specify user namespace path
 
 .PP

--- a/slirp4netns.1.md
+++ b/slirp4netns.1.md
@@ -53,10 +53,10 @@ API socket path
 **-6**, **--enable-ipv6**
 enable IPv6 (experimental).
 
-**--netns-type=TYPE**
+**--netns-type=TYPE** (since v0.4.0)
 specify network namespace type ([path|pid], default=pid)
 
-**--userns-path=PATH**
+**--userns-path=PATH** (since v0.4.0)
 specify user namespace path
 
 **-h**, **--help**

--- a/slirp4netns.1.md
+++ b/slirp4netns.1.md
@@ -34,7 +34,9 @@ bring up the interface. IP will be set to 10.0.2.100 (network address + 100) by 
 specify the FD for terminating slirp4netns.
 
 **-r**, **--ready-fd=FD**
-specify the FD to write to when the network is configured.
+specify the FD to write to when the initialization steps are finished.
+Prior to v0.4.0, the FD was written after the network configuration (**-c**)
+but before the API socket configuration (**-a**).
 
 **-m**, **--mtu=MTU**
 specify MTU (max=65521).

--- a/slirp4netns.c
+++ b/slirp4netns.c
@@ -275,7 +275,7 @@ Slirp *create_slirp(void *opaque, struct slirp4netns_config *s4nn)
 
 #define ETH_BUF_SIZE (65536)
 
-int do_slirp(int tapfd, int exitfd, const char *api_socket,
+int do_slirp(int tapfd, int readyfd, int exitfd, const char *api_socket,
              struct slirp4netns_config *cfg)
 {
     int ret = -1;
@@ -325,6 +325,13 @@ int do_slirp(int tapfd, int exitfd, const char *api_socket,
         pollfds_apifd_idx = n_fds - 1;
     }
     signal(SIGPIPE, SIG_IGN);
+    if (readyfd >= 0) {
+        int rc = -1;
+        do
+            rc = write(readyfd, "1", 1);
+        while (rc < 0 && errno == EINTR);
+        close(readyfd);
+    }
     while (1) {
         int pollout;
         GPollFD *pollfds_data;

--- a/slirp4netns.h
+++ b/slirp4netns.h
@@ -13,6 +13,6 @@ struct slirp4netns_config {
 	bool enable_ipv6;
 	bool disable_host_loopback;
 };
-int do_slirp(int tapfd, int exitfd, const char *api_socket, struct slirp4netns_config *cfg);
+int do_slirp(int tapfd, int readyfd, int exitfd, const char *api_socket, struct slirp4netns_config *cfg);
 
 #endif


### PR DESCRIPTION
Previously, --ready-fd was written when the network configuration (-c)
is ready, but at that time the API socket was not ready to use.

Fix #90