### PR TITLE
update parson

### DIFF
--- a/vendor.sh
+++ b/vendor.sh
@@ -4,8 +4,8 @@ set -eux -o pipefail
 LIBSLIRP_COMMIT=113a219a69adc730ffa860c3f432049f8aa8f714
 LIBSLIRP_REPO=https://gitlab.freedesktop.org/slirp/libslirp.git
 
-# May 14, 2019
-PARSON_COMMIT=33e5519d0ae68784c91c92af2f48a5b07dc14490
+# Jul 12, 2019
+PARSON_COMMIT=c5bb9557fe98367aa8e041c65863909f12ee76b2
 PARSON_REPO=https://github.com/kgabis/parson.git
 
 # prepare

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -2,7 +2,7 @@
 
 Vendored components:
 * libslirp: https://gitlab.freedesktop.org/slirp/libslirp.git (`113a219a69adc730ffa860c3f432049f8aa8f714`)
-* parson: https://github.com/kgabis/parson.git (`33e5519d0ae68784c91c92af2f48a5b07dc14490`)
+* parson: https://github.com/kgabis/parson.git (`c5bb9557fe98367aa8e041c65863909f12ee76b2`)
 
 Applied patches (sha256sum):
 ```

--- a/vendor/parson/LICENSE
+++ b/vendor/parson/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2012 - 2017 Krzysztof Gabis
+Copyright (c) 2012 - 2019 Krzysztof Gabis
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/vendor/parson/parson.c
+++ b/vendor/parson/parson.c
@@ -1,6 +1,8 @@
 /*
+ SPDX-License-Identifier: MIT
+
  Parson ( http://kgabis.github.com/parson/ )
- Copyright (c) 2012 - 2017 Krzysztof Gabis
+ Copyright (c) 2012 - 2019 Krzysztof Gabis
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/vendor/parson/parson.h
+++ b/vendor/parson/parson.h
@@ -1,6 +1,8 @@
 /*
+ SPDX-License-Identifier: MIT
+
  Parson ( http://kgabis.github.com/parson/ )
- Copyright (c) 2012 - 2017 Krzysztof Gabis
+ Copyright (c) 2012 - 2019 Krzysztof Gabis
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
No substantial change. Addition of SPDX-License-Identifier only.

Signed-off-by: Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp>