### PR TITLE
Fix clang-tidy 8 issues

### DIFF
--- a/main.c
+++ b/main.c
@@ -66,8 +66,6 @@ static int nsenter(pid_t target_pid, char *netns, char *userns)
         return -1;
     }
     close(netnsfd);
-    free(netns);
-    free(userns);
     return 0;
 }
 
@@ -358,9 +356,14 @@ static void options_destroy(struct options *options)
         free(options->netns_type);
         options->netns_type = NULL;
     }
-    // options->netns_path and options->userns_path are
-    // getting freed in the nsenter function
-    // options itself is not freed, because it can be on the stack.
+    if (options->netns_path != NULL) {
+        free(options->netns_path);
+        options->netns_path = NULL;
+    }
+    if (options->userns_path != NULL) {
+        free(options->userns_path);
+        options->userns_path = NULL;
+    }
 }
 
 // * caller does not need to call options_init()
@@ -403,8 +406,7 @@ static void parse_args(int argc, char *const argv[], struct options *options)
             options->exit_fd = strtol(optarg, NULL, 10);
             if (errno) {
                 perror("strtol");
-                usage(argv[0]);
-                exit(EXIT_FAILURE);
+                goto error;
             }
             break;
         case 'r':
@@ -412,8 +414,7 @@ static void parse_args(int argc, char *const argv[], struct options *options)
             options->ready_fd = strtol(optarg, NULL, 10);
             if (errno) {
                 perror("strtol");
-                usage(argv[0]);
-                exit(EXIT_FAILURE);
+                goto error;
             }
             break;
         case 'm':
@@ -421,8 +422,7 @@ static void parse_args(int argc, char *const argv[], struct options *options)
             options->mtu = strtol(optarg, NULL, 10);
             if (errno) {
                 perror("strtol");
-                usage(argv[0]);
-                exit(EXIT_FAILURE);
+                goto error;
             }
             break;
         case CIDR:
@@ -446,8 +446,7 @@ static void parse_args(int argc, char *const argv[], struct options *options)
             if (access(options->userns_path, F_OK) == -1) {
                 fprintf(stderr, "userns path doesn't exist: %s\n",
                         options->userns_path);
-                usage(argv[0]);
-                exit(EXIT_FAILURE);
+                goto error;
             }
             break;
         case 'a':
@@ -460,12 +459,14 @@ static void parse_args(int argc, char *const argv[], struct options *options)
         case 'h':
             usage(argv[0]);
             exit(EXIT_SUCCESS);
+            break;
         case 'v':
             version();
             exit(EXIT_SUCCESS);
+            break;
         default:
-            usage(argv[0]);
-            exit(EXIT_FAILURE);
+            goto error;
+            break;
         }
     }
 #undef CIDR
@@ -475,11 +476,10 @@ static void parse_args(int argc, char *const argv[], struct options *options)
 #undef _DEPRECATED_NO_HOST_LOOPBACK
     if (options->mtu == 0 || options->mtu > 65521) {
         fprintf(stderr, "MTU must be a positive integer (< 65522)\n");
-        exit(EXIT_FAILURE);
+        goto error;
     }
     if (argc - optind < 2) {
-        usage(argv[0]);
-        exit(EXIT_FAILURE);
+        goto error;
     }
     if (!options->netns_type ||
         strcmp(options->netns_type, DEFAULT_NETNS_TYPE) == 0) {
@@ -487,18 +487,21 @@ static void parse_args(int argc, char *const argv[], struct options *options)
         options->target_pid = strtol(argv[optind], NULL, 10);
         if (errno != 0) {
             perror("strtol");
-            usage(argv[0]);
-            exit(EXIT_FAILURE);
+            goto error;
         }
     } else {
         options->netns_path = strdup(argv[optind]);
         if (access(options->netns_path, F_OK) == -1) {
             perror("existing path expected when --netns-type=path");
-            usage(argv[0]);
-            exit(EXIT_FAILURE);
+            goto error;
         }
     }
     options->tapname = strdup(argv[optind + 1]);
+    return;
+error:
+    usage(argv[0]);
+    options_destroy(options);
+    exit(EXIT_FAILURE);
 }
 
 static int from_regmatch(char *buf, size_t buf_len, regmatch_t match,


### PR DESCRIPTION
clang-tidy seems to hate `strdup(optarg)` in the `while(getopt())` loop.

Fix #112 