### PR TITLE
vendor libslirp@76462e2f16c6fce6856fb914cbef6207d0be4bc5 (v0.4.0-beta.3)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.69])
-AC_INIT([slirp4netns], [0.4.0-beta.2+dev], [https://github.com/rootless-containers/slirp4netns/issues])
+AC_INIT([slirp4netns], [0.4.0-beta.3], [https://github.com/rootless-containers/slirp4netns/issues])
 AC_CONFIG_SRCDIR([main.c])
 AC_CONFIG_HEADERS([config.h])
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.69])
-AC_INIT([slirp4netns], [0.4.0-beta.3], [https://github.com/rootless-containers/slirp4netns/issues])
+AC_INIT([slirp4netns], [0.4.0-beta.3+dev], [https://github.com/rootless-containers/slirp4netns/issues])
 AC_CONFIG_SRCDIR([main.c])
 AC_CONFIG_HEADERS([config.h])
 

--- a/vendor.sh
+++ b/vendor.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eux -o pipefail
-# Aug 1, 2019
-LIBSLIRP_COMMIT=30804efc8f80f43d415057f3099c2894b0f947c4
+# Aug 2, 2019
+LIBSLIRP_COMMIT=76462e2f16c6fce6856fb914cbef6207d0be4bc5
 LIBSLIRP_REPO=https://gitlab.freedesktop.org/slirp/libslirp.git
 
 # Jul 12, 2019

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -1,7 +1,7 @@
 # DO NOT EDIT MANUALLY
 
 Vendored components:
-* libslirp: https://gitlab.freedesktop.org/slirp/libslirp.git (`30804efc8f80f43d415057f3099c2894b0f947c4`)
+* libslirp: https://gitlab.freedesktop.org/slirp/libslirp.git (`76462e2f16c6fce6856fb914cbef6207d0be4bc5`)
 * parson: https://github.com/kgabis/parson.git (`c5bb9557fe98367aa8e041c65863909f12ee76b2`)
 
 Please do not edit the contents under this directory manually.

--- a/vendor/libslirp/src/bootp.c
+++ b/vendor/libslirp/src/bootp.c
@@ -350,14 +350,12 @@ static void bootp_reply(Slirp *slirp, const struct bootp_t *bp)
         q += sizeof(nak_msg) - 1;
     }
     assert(q < end);
-    *q =
-RFC1533_END
-;
+    *q = RFC1533_END;
 
-daddr.sin_addr.s_addr = 0xffffffffu;
+    daddr.sin_addr.s_addr = 0xffffffffu;
 
-m->m_len = sizeof(struct bootp_t) - sizeof(struct ip) - sizeof(struct udphdr);
-udp_output(NULL, m, &saddr, &daddr, IPTOS_LOWDELAY);
+    m->m_len = sizeof(struct bootp_t) - sizeof(struct ip) - sizeof(struct udphdr);
+    udp_output(NULL, m, &saddr, &daddr, IPTOS_LOWDELAY);
 }
 
 void bootp_input(struct mbuf *m)

--- a/vendor/libslirp/src/ip_input.c
+++ b/vendor/libslirp/src/ip_input.c
@@ -344,11 +344,10 @@ insert:
     q = fp->frag_link.next;
 
     /*
-     * If the fragments concatenated to an mbuf that's
-     * bigger than the total size of the fragment, then and
-     * m_ext buffer was alloced. But fp->ipq_next points to
-     * the old buffer (in the mbuf), so we must point ip
-     * into the new buffer.
+     * If the fragments concatenated to an mbuf that's bigger than the total
+     * size of the fragment and the mbuf was not already using an m_ext buffer,
+     * then an m_ext buffer was alloced. But fp->ipq_next points to the old
+     * buffer (in the mbuf), so we must point ip into the new buffer.
      */
     if (!was_ext && m->m_flags & M_EXT) {
         int delta = (char *)q - m->m_dat;

--- a/vendor/libslirp/src/libslirp.h
+++ b/vendor/libslirp/src/libslirp.h
@@ -70,7 +70,7 @@ typedef struct SlirpCb {
 #define SLIRP_CONFIG_VERSION_MAX 1
 
 typedef struct SlirpConfig {
-    /* Version must be already provided */
+    /* Version must be provided */
     uint32_t version;
     /*
      * Fields introduced in SlirpConfig version 1 begin
@@ -99,6 +99,11 @@ typedef struct SlirpConfig {
     size_t if_mru;
     /* Prohibit connecting to 127.0.0.1:* */
     bool disable_host_loopback;
+    /*
+     * Enable emulation code (*warning*: this code isn't safe, it is not
+     * recommended to enable it)
+     */
+    bool enable_emu;
     /*
      * Fields introduced in SlirpConfig version 2 begin
      */

--- a/vendor/libslirp/src/slirp.c
+++ b/vendor/libslirp/src/slirp.c
@@ -321,6 +321,7 @@ Slirp *slirp_new(const SlirpConfig *cfg, const SlirpCb *callbacks, void *opaque)
     slirp->if_mtu = cfg->if_mtu == 0 ? IF_MTU_DEFAULT : cfg->if_mtu;
     slirp->if_mru = cfg->if_mru == 0 ? IF_MRU_DEFAULT : cfg->if_mru;
     slirp->disable_host_loopback = cfg->disable_host_loopback;
+    slirp->enable_emu = cfg->enable_emu;
 
     return slirp;
 }

--- a/vendor/libslirp/src/slirp.h
+++ b/vendor/libslirp/src/slirp.h
@@ -195,6 +195,8 @@ struct Slirp {
     GRand *grand;
     void *ra_timer;
 
+    bool enable_emu;
+
     const SlirpCb *cb;
     void *opaque;
 };

--- a/vendor/libslirp/src/tcp_subr.c
+++ b/vendor/libslirp/src/tcp_subr.c
@@ -556,34 +556,22 @@ static const struct tos_t tcptos[] = {
     { 0, 0, 0, 0 }
 };
 
-static struct emu_t *tcpemu = NULL;
-
 /*
  * Return TOS according to the above table
  */
 uint8_t tcp_tos(struct socket *so)
 {
     int i = 0;
-    struct emu_t *emup;
 
     while (tcptos[i].tos) {
         if ((tcptos[i].fport && (ntohs(so->so_fport) == tcptos[i].fport)) ||
             (tcptos[i].lport && (ntohs(so->so_lport) == tcptos[i].lport))) {
-            so->so_emu = tcptos[i].emu;
+            if (so->slirp->enable_emu)
+                so->so_emu = tcptos[i].emu;
             return tcptos[i].tos;
         }
         i++;
     }
-
-    /* Nope, lets see if there's a user-added one */
-    for (emup = tcpemu; emup; emup = emup->next) {
-        if ((emup->fport && (ntohs(so->so_fport) == emup->fport)) ||
-            (emup->lport && (ntohs(so->so_lport) == emup->lport))) {
-            so->so_emu = emup->emu;
-            return emup->tos;
-        }
-    }
-
     return 0;
 }
 

--- a/vendor/libslirp/src/udp.c
+++ b/vendor/libslirp/src/udp.c
@@ -302,7 +302,8 @@ static uint8_t udp_tos(struct socket *so)
     while (udptos[i].tos) {
         if ((udptos[i].fport && ntohs(so->so_fport) == udptos[i].fport) ||
             (udptos[i].lport && ntohs(so->so_lport) == udptos[i].lport)) {
-            so->so_emu = udptos[i].emu;
+            if (so->slirp->enable_emu)
+                so->so_emu = udptos[i].emu;
             return udptos[i].tos;
         }
         i++;


### PR DESCRIPTION
https://gitlab.freedesktop.org/slirp/libslirp/compare/30804efc8f80f43d415057f3099c2894b0f947c4...76462e2f16c6fce6856fb914cbef6207d0be4bc5

Now the legacy `tcp_emu()` is disabled

Signed-off-by: Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp>