### PR TITLE
v0.4.0-beta.4

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.69])
-AC_INIT([slirp4netns], [0.4.0-beta.3+dev], [https://github.com/rootless-containers/slirp4netns/issues])
+AC_INIT([slirp4netns], [0.4.0-beta.4], [https://github.com/rootless-containers/slirp4netns/issues])
 AC_CONFIG_SRCDIR([main.c])
 AC_CONFIG_HEADERS([config.h])
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.69])
-AC_INIT([slirp4netns], [0.4.0-beta.4], [https://github.com/rootless-containers/slirp4netns/issues])
+AC_INIT([slirp4netns], [0.4.0-beta.4+dev], [https://github.com/rootless-containers/slirp4netns/issues])
 AC_CONFIG_SRCDIR([main.c])
 AC_CONFIG_HEADERS([config.h])
 


### PR DESCRIPTION
Notable changes since v0.3.0:

* Support specifying netns path (`slirp4netns --netns-type=path PATH TAPNAME`) (#86)
* Support specifying `--userns-path` (#86 )
* Vendor https://gitlab.freedesktop.org/slirp/libslirp (QEMU v4.1+) (#94)
* Bring up loopback device when `--configure` is specified (#99)
* Support sandboxing by creating a mount namespace (`--enable-sandbox`) (#105 #136 #138 )
* Fix heap overflow (#127, https://gitlab.freedesktop.org/slirp/libslirp/commit/126c04acbabd7ad32c2b018fe10dfac2a3bc1210)
* Support seccomp (`--enable-seccomp`) (#134)

**New build dependencies**

* `libcap-devel` (`libcap-dev`)
* `libseccomp-devel` (`libseccomp-dev`)