### PR TITLE
v0.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Early versions prior to v0.2.x | D :warning:
 
 See https://github.com/rootless-containers/slirp4netns/releases for the releases.
 
+See https://github.com/rootless-containers/slirp4netns/security/advisories for the past security advisories.
+
 ## Quick start
 
 ### Install from source

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.69])
-AC_INIT([slirp4netns], [0.4.0], [https://github.com/rootless-containers/slirp4netns/issues])
+AC_INIT([slirp4netns], [0.4.0+dev], [https://github.com/rootless-containers/slirp4netns/issues])
 AC_CONFIG_SRCDIR([main.c])
 AC_CONFIG_HEADERS([config.h])
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.69])
-AC_INIT([slirp4netns], [0.4.0-beta.4+dev], [https://github.com/rootless-containers/slirp4netns/issues])
+AC_INIT([slirp4netns], [0.4.0], [https://github.com/rootless-containers/slirp4netns/issues])
 AC_CONFIG_SRCDIR([main.c])
 AC_CONFIG_HEADERS([config.h])
 


### PR DESCRIPTION
Notable changes since v0.3.0:

* Support specifying netns path (`slirp4netns --netns-type=path PATH TAPNAME`) (#86)
* Support specifying `--userns-path` (#86 )
* Vendor https://gitlab.freedesktop.org/slirp/libslirp (QEMU v4.1+) (#94)
* Bring up loopback device when `--configure` is specified (#99)
* Support sandboxing by creating a mount namespace (`--enable-sandbox`) (#105 #136 #138 )
* libslirp: Fix heap overflow (#127, https://gitlab.freedesktop.org/slirp/libslirp/commit/126c04acbabd7ad32c2b018fe10dfac2a3bc1210)
* Support seccomp (`--enable-seccomp`) (#134)
* libslirp: Fix use-after-free (#140, https://gitlab.freedesktop.org/slirp/libslirp/commit/c59279437eda91841b9d26079c70b8a540d41204)

Note: `--enable-sandbox` was introduced as `--create-sandbox` in beta.2 and renamed to `--enable-sandbox` in beta.4

**New build dependencies**

* `libcap-devel` (`libcap-dev`)
* `libseccomp-devel` (`libseccomp-dev`)