### PR TITLE
sandbox: do not propagate mounts to the parent ns

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -16,6 +16,7 @@ EXTRA_DIST = \
 	api.h \
 	sandbox.h \
 	seccompfilter.h \
+	tests/slirp4netns-no-unmount.sh \
 	vendor/libslirp/COPYRIGHT \
 	vendor/libslirp/README.md \
 	vendor/libslirp/src/bootp.h \

--- a/sandbox.c
+++ b/sandbox.c
@@ -16,11 +16,21 @@ static int add_mount(const char *from, const char *to)
 {
     int ret;
 
+    ret = mount("", from, "", MS_SLAVE | MS_REC, NULL);
+    if (ret < 0 && errno != EINVAL) {
+        fprintf(stderr, "cannot make mount propagation slave %s\n", from);
+        return ret;
+    }
     ret = mount(from, to, "",
                 MS_BIND | MS_REC | MS_SLAVE | MS_NOSUID | MS_NODEV | MS_NOEXEC,
                 NULL);
     if (ret < 0) {
         fprintf(stderr, "cannot bind mount %s to %s\n", from, to);
+        return ret;
+    }
+    ret = mount("", to, "", MS_SLAVE | MS_REC, NULL);
+    if (ret < 0) {
+        fprintf(stderr, "cannot make mount propagation slave %s\n", to);
         return ret;
     }
     ret = mount(from, to, "",

--- a/tests/slirp4netns-no-unmount.sh
+++ b/tests/slirp4netns-no-unmount.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -xeuo pipefail
+
+. $(dirname $0)/common.sh
+
+# it is a part of test-slirp4netns.sh
+# must run in a new mount namespace
+
+mount -t tmpfs tmpfs /run
+mkdir /run/foo
+mount -t tmpfs tmpfs /run/foo
+mount --make-rshared /run
+
+unshare -n sleep infinity &
+child=$!
+
+wait_for_network_namespace $child
+
+./slirp4netns --enable-sandbox --netns-type=path /proc/$child/ns/net tun11 &
+slirp_pid=$!
+
+function cleanup {
+    kill -9 $child $slirp_pid
+}
+trap cleanup EXIT
+
+wait_for_network_device $child tun11
+
+findmnt /run/foo

--- a/tests/test-slirp4netns.sh
+++ b/tests/test-slirp4netns.sh
@@ -67,3 +67,5 @@ wait_for_network_device $child tun11
 
 nsenter --preserve-credentials -U -n --target=$child ip -a netconf | grep tun11
 nsenter --preserve-credentials -U -n --target=$child ip addr show tun11 | grep -v inet
+
+unshare -rm $(readlink -f $(dirname $0)/slirp4netns-no-unmount.sh)


### PR DESCRIPTION
when creating the sandbox, make sure the mounts are marked with
MS_SLAVE so that events are not propagated to other mount namespaces.

Closes: https://github.com/containers/libpod/issues/4113

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>