### PR TITLE
don't return if remount of "/" fails in create_sandbox

### DIFF
--- a/sandbox.c
+++ b/sandbox.c
@@ -135,7 +135,6 @@ int create_sandbox()
     ret = mount("tmpfs", "/", "tmpfs", MS_REMOUNT | MS_RDONLY, "size=0k");
     if (ret < 0) {
         fprintf(stderr, "cannot mount tmpfs on /tmp\n");
-        return ret;
     }
 
     ret = prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0);


### PR DESCRIPTION
This fixes issue #161.
By not returning from create_sandbox() when the remount of "/" fails, slirp4netns continues to operate normally instead of exiting.
I tested this setup for a few days and it seems to work fine.