### PR TITLE
v0.4.3-beta.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.69])
-AC_INIT([slirp4netns], [0.4.3-beta.0], [https://github.com/rootless-containers/slirp4netns/issues])
+AC_INIT([slirp4netns], [0.4.3-beta.0+dev], [https://github.com/rootless-containers/slirp4netns/issues])
 AC_CONFIG_SRCDIR([main.c])
 AC_CONFIG_HEADERS([config.h])
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.69])
-AC_INIT([slirp4netns], [0.4.2+dev], [https://github.com/rootless-containers/slirp4netns/issues])
+AC_INIT([slirp4netns], [0.4.3-beta.0], [https://github.com/rootless-containers/slirp4netns/issues])
 AC_CONFIG_SRCDIR([main.c])
 AC_CONFIG_HEADERS([config.h])
 


### PR DESCRIPTION
Notable changes since v0.4.2:
* api: raise an error if the socket path is too long (#158)
* libslirp: update to v4.1.0: https://gitlab.freedesktop.org/slirp/libslirp/compare/d203c81bc6c861e1671122c3194c21d1a6763641...v4.1.0
  * Including the fix for [`libslirp sends RST to app in response to arriving FIN when containerized socket is shutdown() with SHUT_WR`](https://gitlab.freedesktop.org/slirp/libslirp/issues/12)