### PR TITLE
v0.4.3

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.69])
-AC_INIT([slirp4netns], [0.4.3-beta.1+dev], [https://github.com/rootless-containers/slirp4netns/issues])
+AC_INIT([slirp4netns], [0.4.3], [https://github.com/rootless-containers/slirp4netns/issues])
 AC_CONFIG_SRCDIR([main.c])
 AC_CONFIG_HEADERS([config.h])
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.69])
-AC_INIT([slirp4netns], [0.4.3], [https://github.com/rootless-containers/slirp4netns/issues])
+AC_INIT([slirp4netns], [0.4.3+dev], [https://github.com/rootless-containers/slirp4netns/issues])
 AC_CONFIG_SRCDIR([main.c])
 AC_CONFIG_HEADERS([config.h])
 

--- a/sandbox.c
+++ b/sandbox.c
@@ -134,7 +134,8 @@ int create_sandbox()
 
     ret = mount("tmpfs", "/", "tmpfs", MS_REMOUNT | MS_RDONLY, "size=0k");
     if (ret < 0) {
-        fprintf(stderr, "cannot mount tmpfs on /tmp\n");
+        fprintf(stderr, "cannot remount / as read-only\n");
+        /* error is negligible (#163) */
     }
 
     ret = prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0);


### PR DESCRIPTION
Notable changes since v0.4.2:
* api: raise an error if the socket path is too long (#158)
* libslirp: update to v4.1.0: https://gitlab.freedesktop.org/slirp/libslirp/compare/d203c81bc6c861e1671122c3194c21d1a6763641...v4.1.0
  * Including the fix for [`libslirp sends RST to app in response to arriving FIN when containerized socket is shutdown() with SHUT_WR`](https://gitlab.freedesktop.org/slirp/libslirp/issues/12)
* Binary release for x86_64 is available. The binary is built on GitHub Actions. (#165, #129 
* Fix `create_sandbox` error (#163)