### PR TITLE
add libslirp version to `slirp4netns --version`

### DIFF
--- a/main.c
+++ b/main.c
@@ -19,6 +19,7 @@
 #include <getopt.h>
 #include <stdbool.h>
 #include <regex.h>
+#include <libslirp.h>
 #include "slirp4netns.h"
 
 #define DEFAULT_MTU (1500)
@@ -342,6 +343,7 @@ static void version()
 #ifdef COMMIT
     printf("commit: %s\n", COMMIT);
 #endif
+    printf("libslirp: %s\n", slirp_version_string());
 }
 
 struct options {


### PR DESCRIPTION
```console
$ slirp4netns --version
slirp4netns version 0.4.3+dev
commit: a0b72ba8210552d01c9f7518f615c9d6def7e980
libslirp: 4.2.0
```