### PR TITLE
docker: install meson through pip, since libslirp git requires 0.49

### DIFF
--- a/Dockerfile.buildtests
+++ b/Dockerfile.buildtests
@@ -13,7 +13,8 @@ RUN ./autogen.sh && ./configure LDFLAGS="-static" && make && cp -f slirp4netns /
 
 # Ubuntu
 FROM ubuntu:18.04 AS buildtest-ubuntu1804-common
-RUN apt update && apt install -y automake autotools-dev make gcc libglib2.0-dev libcap-dev libseccomp-dev git meson
+RUN apt update && apt install -y automake autotools-dev make gcc libglib2.0-dev libcap-dev libseccomp-dev git ninja-build python3-pip
+RUN pip3 install meson
 RUN git clone https://gitlab.freedesktop.org/slirp/libslirp.git /libslirp
 WORKDIR /libslirp
 ARG LIBSLIRP_COMMIT

--- a/Dockerfile.tests
+++ b/Dockerfile.tests
@@ -1,7 +1,8 @@
 ARG LIBSLIRP_COMMIT=v4.2.0
 
 FROM ubuntu:18.04 AS build
-RUN apt update && apt install -y automake autotools-dev make gcc libglib2.0-dev libcap-dev libseccomp-dev git meson
+RUN apt update && apt install -y automake autotools-dev make gcc libglib2.0-dev libcap-dev libseccomp-dev git ninja-build python3-pip
+RUN pip3 install meson
 RUN git clone https://gitlab.freedesktop.org/slirp/libslirp.git /libslirp
 WORKDIR /libslirp
 ARG LIBSLIRP_COMMIT


### PR DESCRIPTION
Ubuntu 18.04 has meson 0.45 only.

Signed-off-by: Marc-André Lureau <marcandre.lureau@redhat.com>