### PR TITLE
[release/0.3] vendor libslirp v4.2.0 (release slirp4netns v0.3.5)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.69])
-AC_INIT([slirp4netns], [0.3.5], [https://github.com/rootless-containers/slirp4netns/issues])
+AC_INIT([slirp4netns], [0.3.5+dev], [https://github.com/rootless-containers/slirp4netns/issues])
 AC_CONFIG_SRCDIR([main.c])
 AC_CONFIG_HEADERS([config.h])
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.69])
-AC_INIT([slirp4netns], [0.3.4+dev], [https://github.com/rootless-containers/slirp4netns/issues])
+AC_INIT([slirp4netns], [0.3.5], [https://github.com/rootless-containers/slirp4netns/issues])
 AC_CONFIG_SRCDIR([main.c])
 AC_CONFIG_HEADERS([config.h])
 

--- a/main.c
+++ b/main.c
@@ -18,6 +18,7 @@
 #include <getopt.h>
 #include <stdbool.h>
 #include <regex.h>
+#include "vendor/libslirp/src/libslirp.h"
 #include "slirp4netns.h"
 
 #define DEFAULT_MTU (1500)
@@ -282,6 +283,7 @@ static void version()
 #ifdef COMMIT
 	printf("commit: %s\n", COMMIT);
 #endif
+    printf("libslirp: %s\n", slirp_version_string());
 }
 
 struct options {

--- a/vendor.sh
+++ b/vendor.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 set -eux -o pipefail
-# Dec 4, 2019 (v4.1.0)
-LIBSLIRP_COMMIT=6651ba26c4e94f64d6448a2db4991269ce553bd9
+# Mar 17, 2020 (v4.2.0)
+LIBSLIRP_COMMIT=daba14c3416fa9641ab4453a9a11e7f8bde08875
 LIBSLIRP_REPO=https://gitlab.freedesktop.org/slirp/libslirp.git
 
-# Jul 12, 2019
-PARSON_COMMIT=c5bb9557fe98367aa8e041c65863909f12ee76b2
+# Feb 21, 2020
+PARSON_COMMIT=70dc239f8f54c80bf58477b25435fd3dd3102804
 PARSON_REPO=https://github.com/kgabis/parson.git
 
 # prepare

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -1,8 +1,8 @@
 # DO NOT EDIT MANUALLY
 
 Vendored components:
-* libslirp: https://gitlab.freedesktop.org/slirp/libslirp.git (`6651ba26c4e94f64d6448a2db4991269ce553bd9`)
-* parson: https://github.com/kgabis/parson.git (`c5bb9557fe98367aa8e041c65863909f12ee76b2`)
+* libslirp: https://gitlab.freedesktop.org/slirp/libslirp.git (`daba14c3416fa9641ab4453a9a11e7f8bde08875`)
+* parson: https://github.com/kgabis/parson.git (`70dc239f8f54c80bf58477b25435fd3dd3102804`)
 
 Please do not edit the contents under this directory manually.
 

--- a/vendor/libslirp/src/bootp.c
+++ b/vendor/libslirp/src/bootp.c
@@ -254,9 +254,10 @@ static void bootp_reply(Slirp *slirp, const struct bootp_t *bp)
             *q++ = DHCPACK;
         }
 
-        if (slirp->bootp_filename)
-            snprintf((char *)rbp->bp_file, sizeof(rbp->bp_file), "%s",
-                     slirp->bootp_filename);
+        if (slirp->bootp_filename) {
+            g_assert(strlen(slirp->bootp_filename) < sizeof(rbp->bp_file));
+            strcpy(rbp->bp_file, slirp->bootp_filename);
+        }
 
         *q++ = RFC2132_SRV_ID;
         *q++ = 4;

--- a/vendor/libslirp/src/bootp.h
+++ b/vendor/libslirp/src/bootp.h
@@ -113,7 +113,7 @@ struct bootp_t {
     struct in_addr bp_giaddr;
     uint8_t bp_hwaddr[16];
     uint8_t bp_sname[64];
-    uint8_t bp_file[128];
+    char bp_file[128];
     uint8_t bp_vend[DHCP_OPT_LEN];
 };
 

--- a/vendor/libslirp/src/dhcpv6.c
+++ b/vendor/libslirp/src/dhcpv6.c
@@ -179,13 +179,12 @@ static void dhcpv6_info_request(Slirp *slirp, struct sockaddr_in6 *srcsas,
         *resp++ = OPTION_BOOTFILE_URL >> 8; /* option-code high byte */
         *resp++ = OPTION_BOOTFILE_URL; /* option-code low byte */
         smaxlen = (uint8_t *)m->m_data + slirp->if_mtu - (resp + 2);
-        slen = snprintf((char *)resp + 2, smaxlen,
-                        "tftp://[%02x%02x:%02x%02x:%02x%02x:%02x%02x:"
-                        "%02x%02x:%02x%02x:%02x%02x:%02x%02x]/%s",
-                        sa[0], sa[1], sa[2], sa[3], sa[4], sa[5], sa[6], sa[7],
-                        sa[8], sa[9], sa[10], sa[11], sa[12], sa[13], sa[14],
-                        sa[15], slirp->bootp_filename);
-        slen = MIN(slen, smaxlen);
+        slen = slirp_fmt((char *)resp + 2, smaxlen,
+                         "tftp://[%02x%02x:%02x%02x:%02x%02x:%02x%02x:"
+                         "%02x%02x:%02x%02x:%02x%02x:%02x%02x]/%s",
+                         sa[0], sa[1], sa[2], sa[3], sa[4], sa[5], sa[6], sa[7],
+                         sa[8], sa[9], sa[10], sa[11], sa[12], sa[13], sa[14],
+                         sa[15], slirp->bootp_filename);
         *resp++ = slen >> 8; /* option-len high byte */
         *resp++ = slen; /* option-len low byte */
         resp += slen;

--- a/vendor/libslirp/src/ip_icmp.c
+++ b/vendor/libslirp/src/ip_icmp.c
@@ -90,6 +90,13 @@ static int icmp_send(struct socket *so, struct mbuf *m, int hlen)
         return -1;
     }
 
+    if (slirp_bind_outbound(so, AF_INET) != 0) {
+        // bind failed - close socket
+        closesocket(so->s);
+        so->s = -1;
+        return -1;
+    }
+
     so->so_m = m;
     so->so_faddr = ip->ip_dst;
     so->so_laddr = ip->ip_src;

--- a/vendor/libslirp/src/libslirp-version.h
+++ b/vendor/libslirp/src/libslirp-version.h
@@ -7,7 +7,7 @@ extern "C" {
 #endif
 
 #define SLIRP_MAJOR_VERSION 4
-#define SLIRP_MINOR_VERSION 1
+#define SLIRP_MINOR_VERSION 2
 #define SLIRP_MICRO_VERSION 0
 
 #define SLIRP_CHECK_VERSION(major,minor,micro)                          \

--- a/vendor/libslirp/src/libslirp.h
+++ b/vendor/libslirp/src/libslirp.h
@@ -67,7 +67,7 @@ typedef struct SlirpCb {
 } SlirpCb;
 
 #define SLIRP_CONFIG_VERSION_MIN 1
-#define SLIRP_CONFIG_VERSION_MAX 1
+#define SLIRP_CONFIG_VERSION_MAX 2
 
 typedef struct SlirpConfig {
     /* Version must be provided */
@@ -107,6 +107,8 @@ typedef struct SlirpConfig {
     /*
      * Fields introduced in SlirpConfig version 2 begin
      */
+    struct sockaddr_in *outbound_addr;
+    struct sockaddr_in6 *outbound_addr6;
 } SlirpConfig;
 
 Slirp *slirp_new(const SlirpConfig *cfg, const SlirpCb *callbacks,
@@ -138,8 +140,13 @@ int slirp_remove_hostfwd(Slirp *slirp, int is_udp, struct in_addr host_addr,
                          int host_port);
 int slirp_add_exec(Slirp *slirp, const char *cmdline,
                    struct in_addr *guest_addr, int guest_port);
+int slirp_add_unix(Slirp *slirp, const char *unixsock,
+                   struct in_addr *guest_addr, int guest_port);
 int slirp_add_guestfwd(Slirp *slirp, SlirpWriteCb write_cb, void *opaque,
                        struct in_addr *guest_addr, int guest_port);
+/* remove entries added by slirp_add_exec, slirp_add_unix or slirp_add_guestfwd */
+int slirp_remove_guestfwd(Slirp *slirp, struct in_addr guest_addr,
+                          int guest_port);
 
 char *slirp_connection_info(Slirp *slirp);
 

--- a/vendor/libslirp/src/misc.h
+++ b/vendor/libslirp/src/misc.h
@@ -14,6 +14,7 @@ struct gfwd_list {
     struct in_addr ex_addr; /* Server address */
     int ex_fport; /* Port to telnet to */
     char *ex_exec; /* Command line of what to exec */
+    char *ex_unix; /* unix socket */
     struct gfwd_list *ex_next;
 };
 
@@ -53,11 +54,19 @@ struct slirp_quehead {
 void slirp_insque(void *, void *);
 void slirp_remque(void *);
 int fork_exec(struct socket *so, const char *ex);
+int open_unix(struct socket *so, const char *unixsock);
 
 struct gfwd_list *add_guestfwd(struct gfwd_list **ex_ptr, SlirpWriteCb write_cb,
                                void *opaque, struct in_addr addr, int port);
 
 struct gfwd_list *add_exec(struct gfwd_list **ex_ptr, const char *cmdline,
                            struct in_addr addr, int port);
+
+struct gfwd_list *add_unix(struct gfwd_list **ex_ptr, const char *unixsock,
+                           struct in_addr addr, int port);
+
+int remove_guestfwd(struct gfwd_list **ex_ptr, struct in_addr addr, int port);
+
+int slirp_bind_outbound(struct socket *so, unsigned short af);
 
 #endif

--- a/vendor/libslirp/src/ncsi.c
+++ b/vendor/libslirp/src/ncsi.c
@@ -47,7 +47,7 @@ static uint32_t ncsi_calculate_checksum(uint16_t *data, int len)
      * 32-bit unsigned sum of the NC-SI packet header and NC-SI packet
      * payload interpreted as a series of 16-bit unsigned integer values.
      */
-    for (i = 0; i < len; i++) {
+    for (i = 0; i < len / 2; i++) {
         checksum += htons(data[i]);
     }
 

--- a/vendor/libslirp/src/slirp.h
+++ b/vendor/libslirp/src/slirp.h
@@ -199,6 +199,9 @@ struct Slirp {
 
     const SlirpCb *cb;
     void *opaque;
+
+    struct sockaddr_in *outbound_addr;
+    struct sockaddr_in6 *outbound_addr6;
 };
 
 void if_start(Slirp *);

--- a/vendor/libslirp/src/state.c
+++ b/vendor/libslirp/src/state.c
@@ -366,6 +366,8 @@ int slirp_state_load(Slirp *slirp, int version_id, SlirpReadCb read_cb,
         if (!ex_ptr) {
             return -EINVAL;
         }
+
+        so->guestfwd = ex_ptr;
     }
 
     return slirp_vmstate_load_state(&f, &vmstate_slirp, slirp, version_id);

--- a/vendor/libslirp/src/udp.c
+++ b/vendor/libslirp/src/udp.c
@@ -279,6 +279,12 @@ int udp_attach(struct socket *so, unsigned short af)
 {
     so->s = slirp_socket(af, SOCK_DGRAM, 0);
     if (so->s != -1) {
+        if (slirp_bind_outbound(so, af) != 0) {
+            // bind failed - close socket
+            closesocket(so->s);
+            so->s = -1;
+            return -1;
+        }
         so->so_expire = curtime + SO_EXPIRE;
         insque(so, &so->slirp->udb);
     }

--- a/vendor/libslirp/src/util.c
+++ b/vendor/libslirp/src/util.c
@@ -364,3 +364,65 @@ void slirp_pstrcpy(char *buf, int buf_size, const char *str)
     }
     *q = '\0';
 }
+
+static int slirp_vsnprintf(char *str, size_t size,
+                           const char *format, va_list args)
+{
+    int rv = g_vsnprintf(str, size, format, args);
+
+    if (rv < 0) {
+        g_error("g_vsnprintf() failed: %s", g_strerror(errno));
+    }
+
+    return rv;
+}
+
+/*
+ * A snprintf()-like function that:
+ * - returns the number of bytes written (excluding optional \0-ending)
+ * - dies on error
+ * - warn on truncation
+ */
+int slirp_fmt(char *str, size_t size, const char *format, ...)
+{
+    va_list args;
+    int rv;
+
+    va_start(args, format);
+    rv = slirp_vsnprintf(str, size, format, args);
+    va_end(args);
+
+    if (rv > size) {
+        g_critical("slirp_fmt() truncation");
+    }
+
+    return MIN(rv, size);
+}
+
+/*
+ * A snprintf()-like function that:
+ * - always \0-end (unless size == 0)
+ * - returns the number of bytes actually written, including \0 ending
+ * - dies on error
+ * - warn on truncation
+ */
+int slirp_fmt0(char *str, size_t size, const char *format, ...)
+{
+    va_list args;
+    int rv;
+
+    va_start(args, format);
+    rv = slirp_vsnprintf(str, size, format, args);
+    va_end(args);
+
+    if (rv >= size) {
+        g_critical("slirp_fmt0() truncation");
+        if (size > 0)
+            str[size - 1] = '\0';
+        rv = size;
+    } else {
+        rv += 1; /* include \0 */
+    }
+
+    return rv;
+}

--- a/vendor/libslirp/src/util.h
+++ b/vendor/libslirp/src/util.h
@@ -24,6 +24,8 @@
 #ifndef UTIL_H_
 #define UTIL_H_
 
+#include <glib.h>
+
 #include <stdlib.h>
 #include <stdio.h>
 #include <assert.h>
@@ -59,6 +61,10 @@
         void *__mptr = (void *)(ptr);                \
         ((type *)(__mptr - offsetof(type, member))); \
     })
+#endif
+
+#ifndef G_SIZEOF_MEMBER
+#define G_SIZEOF_MEMBER(type, member) sizeof(((type *)0)->member)
 #endif
 
 #if defined(_WIN32) /* CONFIG_IOVEC */
@@ -176,5 +182,8 @@ static inline int slirp_socket_set_fast_reuse(int fd)
 }
 
 void slirp_pstrcpy(char *buf, int buf_size, const char *str);
+
+int slirp_fmt(char *str, size_t size, const char *format, ...) G_GNUC_PRINTF(3, 4);
+int slirp_fmt0(char *str, size_t size, const char *format, ...) G_GNUC_PRINTF(3, 4);
 
 #endif

--- a/vendor/parson/parson.c
+++ b/vendor/parson/parson.c
@@ -1,7 +1,7 @@
 /*
  SPDX-License-Identifier: MIT
 
- Parson ( http://kgabis.github.com/parson/ )
+ Parson 1.0.2 ( http://kgabis.github.com/parson/ )
  Copyright (c) 2012 - 2019 Krzysztof Gabis
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -156,7 +156,7 @@ static char * parson_strndup(const char *string, size_t n) {
         return NULL;
     }
     output_string[n] = '\0';
-    strncpy(output_string, string, n);
+    memcpy(output_string, string, n);
     return output_string;
 }
 
@@ -1496,7 +1496,7 @@ JSON_Value * json_value_deep_copy(const JSON_Value *value) {
 size_t json_serialization_size(const JSON_Value *value) {
     char num_buf[NUM_BUF_SIZE]; /* recursively allocating buffer on stack is a bad idea, so let's do it only once */
     int res = json_serialize_to_buffer_r(value, NULL, 0, 0, num_buf);
-    return res < 0 ? 0 : (size_t)(res + 1);
+    return res < 0 ? 0 : (size_t)(res) + 1;
 }
 
 JSON_Status json_serialize_to_buffer(const JSON_Value *value, char *buf, size_t buf_size_in_bytes) {
@@ -1556,7 +1556,7 @@ char * json_serialize_to_string(const JSON_Value *value) {
 size_t json_serialization_size_pretty(const JSON_Value *value) {
     char num_buf[NUM_BUF_SIZE]; /* recursively allocating buffer on stack is a bad idea, so let's do it only once */
     int res = json_serialize_to_buffer_r(value, NULL, 0, 1, num_buf);
-    return res < 0 ? 0 : (size_t)(res + 1);
+    return res < 0 ? 0 : (size_t)(res) + 1;
 }
 
 JSON_Status json_serialize_to_buffer_pretty(const JSON_Value *value, char *buf, size_t buf_size_in_bytes) {
@@ -1776,19 +1776,39 @@ JSON_Status json_object_set_value(JSON_Object *object, const char *name, JSON_Va
 }
 
 JSON_Status json_object_set_string(JSON_Object *object, const char *name, const char *string) {
-    return json_object_set_value(object, name, json_value_init_string(string));
+    JSON_Value *value = json_value_init_string(string);
+    JSON_Status status = json_object_set_value(object, name, value);
+    if (status == JSONFailure) {
+        json_value_free(value);
+    }
+    return status;
 }
 
 JSON_Status json_object_set_number(JSON_Object *object, const char *name, double number) {
-    return json_object_set_value(object, name, json_value_init_number(number));
+    JSON_Value *value = json_value_init_number(number);
+    JSON_Status status = json_object_set_value(object, name, value);
+    if (status == JSONFailure) {
+        json_value_free(value);
+    }
+    return status;
 }
 
 JSON_Status json_object_set_boolean(JSON_Object *object, const char *name, int boolean) {
-    return json_object_set_value(object, name, json_value_init_boolean(boolean));
+    JSON_Value *value = json_value_init_boolean(boolean);
+    JSON_Status status = json_object_set_value(object, name, value);
+    if (status == JSONFailure) {
+        json_value_free(value);
+    }
+    return status;
 }
 
 JSON_Status json_object_set_null(JSON_Object *object, const char *name) {
-    return json_object_set_value(object, name, json_value_init_null());
+    JSON_Value *value = json_value_init_null();
+    JSON_Status status = json_object_set_value(object, name, value);
+    if (status == JSONFailure) {
+        json_value_free(value);
+    }
+    return status;
 }
 
 JSON_Status json_object_dotset_value(JSON_Object *object, const char *name, JSON_Value *value) {

--- a/vendor/parson/parson.h
+++ b/vendor/parson/parson.h
@@ -1,7 +1,7 @@
 /*
  SPDX-License-Identifier: MIT
 
- Parson ( http://kgabis.github.com/parson/ )
+ Parson 1.0.2 ( http://kgabis.github.com/parson/ )
  Copyright (c) 2012 - 2019 Krzysztof Gabis
 
  Permission is hereby granted, free of charge, to any person obtaining a copy


### PR DESCRIPTION
Notable changes since v0.4.3:
* libslirp: update to v4.2.0: https://gitlab.freedesktop.org/slirp/libslirp/-/blob/v4.2.0/CHANGELOG.md

This release is expected to be the last official release for v0.3.x .