### PR TITLE
v1.0.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.69])
-AC_INIT([slirp4netns], [1.0.0], [https://github.com/rootless-containers/slirp4netns/issues])
+AC_INIT([slirp4netns], [1.0.0+dev], [https://github.com/rootless-containers/slirp4netns/issues])
 AC_CONFIG_SRCDIR([main.c])
 AC_CONFIG_HEADERS([config.h])
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.69])
-AC_INIT([slirp4netns], [1.0.0-beta.0+dev], [https://github.com/rootless-containers/slirp4netns/issues])
+AC_INIT([slirp4netns], [1.0.0], [https://github.com/rootless-containers/slirp4netns/issues])
 AC_CONFIG_SRCDIR([main.c])
 AC_CONFIG_HEADERS([config.h])
 


### PR DESCRIPTION
Notable changes since v0.4.3:
* [libslirp](https://gitlab.freedesktop.org/slirp/libslirp) is no longer included in slirp4netns and needs be installed separately. Binary release (`slirp4netns-x86_64`) is statically built with libslirp v4.2.0. https://gitlab.freedesktop.org/slirp/libslirp/-/blob/v4.2.0/CHANGELOG.md
* `--enable-sandbox` is now out of experimental (#193)

**New build dependeny**: `libslirp-devel` >= 4.1 (`libslirp-dev`)