### PR TITLE
v1.0.1 (update binary artifact)

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        libslirp_commit: [master, v4.2.0, v4.1.0]
+        libslirp_commit: [master, v4.3.0, v4.2.0, v4.1.0]
     steps:
     - uses: actions/checkout@v1
     - run: docker build -t slirp4netns-tests --build-arg LIBSLIRP_COMMIT -f Dockerfile.tests .

--- a/Dockerfile.buildtests
+++ b/Dockerfile.buildtests
@@ -1,7 +1,7 @@
 ARG LIBSLIRP_COMMIT=v4.3.0
 
 # Alpine
-FROM alpine:3.10 AS buildtest-alpine310-static
+FROM alpine:3 AS buildtest-alpine3-static
 RUN apk add --no-cache git build-base autoconf automake libtool linux-headers glib-dev glib-static libcap-static libcap-dev libseccomp-dev git meson
 RUN git clone https://gitlab.freedesktop.org/slirp/libslirp.git /libslirp
 WORKDIR /libslirp
@@ -27,7 +27,7 @@ FROM buildtest-ubuntu1804-common AS buildtest-ubuntu1804-dynamic
 RUN ./configure && make && cp -f slirp4netns /
 
 # CentOS
-FROM centos:7.6.1810 AS buildtest-centos76-common
+FROM centos:7 AS buildtest-centos7-common
 RUN yum install -y epel-release
 RUN yum install -y autoconf automake gcc glib2-devel git make libcap-devel libseccomp-devel ninja-build python3-pip
 RUN pip3 install meson
@@ -39,17 +39,17 @@ COPY . /src
 WORKDIR /src
 RUN ./autogen.sh
 
-FROM buildtest-centos76-common AS buildtest-centos76-dynamic
+FROM buildtest-centos7-common AS buildtest-centos7-dynamic
 RUN ./configure && make && cp -f slirp4netns /
 
-FROM buildtest-centos76-common AS buildtest-centos76-static
+FROM buildtest-centos7-common AS buildtest-centos7-static
 RUN yum install -y glibc-static glib2-static
 RUN yum-config-manager --add-repo=https://buildlogs.centos.org/centos/7/virt/x86_64/container && \
  yum install --nogpgcheck -y libseccomp-static
 RUN ./configure LDFLAGS="-static" && make && cp -f slirp4netns /
 
 # openSUSE (dynamic only)
-FROM opensuse/leap:15.1 AS buildtest-opensuse151-common
+FROM opensuse/leap:15 AS buildtest-opensuse15-common
 RUN zypper install -y --no-recommends autoconf automake gcc glib2-devel git make libcap-devel libseccomp-devel ninja python3-pip
 RUN pip3 install meson
 RUN git clone https://gitlab.freedesktop.org/slirp/libslirp.git /libslirp
@@ -60,16 +60,16 @@ COPY . /src
 WORKDIR /src
 RUN ./autogen.sh
 
-FROM buildtest-opensuse151-common AS buildtest-opensuse151-dynamic
+FROM buildtest-opensuse15-common AS buildtest-opensuse15-dynamic
 RUN ./configure && make && cp -f slirp4netns /
 
 # artifact for GitHub actions
 FROM scratch AS artifact
-COPY --from=buildtest-alpine310-static /slirp4netns /slirp4netns
+COPY --from=buildtest-alpine3-static /slirp4netns /slirp4netns
 
 FROM scratch AS buildtest-final-stage
-COPY --from=buildtest-alpine310-static /slirp4netns /buildtest-alpine310-static
+COPY --from=buildtest-alpine3-static /slirp4netns /buildtest-alpine3-static
 COPY --from=buildtest-ubuntu1804-dynamic /slirp4netns /buildtest-ubuntu1804-dynamic
-COPY --from=buildtest-centos76-dynamic /slirp4netns /buildtest-centos76-dynamic
-COPY --from=buildtest-centos76-static /slirp4netns /buildtest-centos76-static
-COPY --from=buildtest-opensuse151-dynamic /slirp4netns /buildtest-opensuse151-dynamic
+COPY --from=buildtest-centos7-dynamic /slirp4netns /buildtest-centos7-dynamic
+COPY --from=buildtest-centos7-static /slirp4netns /buildtest-centos7-static
+COPY --from=buildtest-opensuse15-dynamic /slirp4netns /buildtest-opensuse15-dynamic

--- a/Dockerfile.buildtests
+++ b/Dockerfile.buildtests
@@ -65,7 +65,7 @@ RUN ./configure && make && cp -f slirp4netns /
 
 # artifact for GitHub actions
 FROM scratch AS artifact
-COPY --from=buildtest-alpine3-static /slirp4netns /slirp4netns
+COPY --from=buildtest-centos7-static /slirp4netns /slirp4netns
 
 FROM scratch AS buildtest-final-stage
 COPY --from=buildtest-alpine3-static /slirp4netns /buildtest-alpine3-static

--- a/Dockerfile.buildtests
+++ b/Dockerfile.buildtests
@@ -1,4 +1,4 @@
-ARG LIBSLIRP_COMMIT=v4.2.0
+ARG LIBSLIRP_COMMIT=v4.3.0
 
 # Alpine
 FROM alpine:3.10 AS buildtest-alpine310-static
@@ -29,7 +29,8 @@ RUN ./configure && make && cp -f slirp4netns /
 # CentOS
 FROM centos:7.6.1810 AS buildtest-centos76-common
 RUN yum install -y epel-release
-RUN yum install -y autoconf automake gcc glib2-devel git make libcap-devel libseccomp-devel meson
+RUN yum install -y autoconf automake gcc glib2-devel git make libcap-devel libseccomp-devel ninja-build python3-pip
+RUN pip3 install meson
 RUN git clone https://gitlab.freedesktop.org/slirp/libslirp.git /libslirp
 WORKDIR /libslirp
 ARG LIBSLIRP_COMMIT
@@ -49,7 +50,8 @@ RUN ./configure LDFLAGS="-static" && make && cp -f slirp4netns /
 
 # openSUSE (dynamic only)
 FROM opensuse/leap:15.1 AS buildtest-opensuse151-common
-RUN zypper install -y --no-recommends autoconf automake gcc glib2-devel git make libcap-devel libseccomp-devel meson
+RUN zypper install -y --no-recommends autoconf automake gcc glib2-devel git make libcap-devel libseccomp-devel ninja python3-pip
+RUN pip3 install meson
 RUN git clone https://gitlab.freedesktop.org/slirp/libslirp.git /libslirp
 WORKDIR /libslirp
 ARG LIBSLIRP_COMMIT

--- a/Dockerfile.tests
+++ b/Dockerfile.tests
@@ -1,4 +1,4 @@
-ARG LIBSLIRP_COMMIT=v4.2.0
+ARG LIBSLIRP_COMMIT=v4.3.0
 
 FROM ubuntu:18.04 AS build
 RUN apt update && apt install -y automake autotools-dev make gcc libglib2.0-dev libcap-dev libseccomp-dev git ninja-build python3-pip

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.69])
-AC_INIT([slirp4netns], [1.0.1], [https://github.com/rootless-containers/slirp4netns/issues])
+AC_INIT([slirp4netns], [1.0.1+dev], [https://github.com/rootless-containers/slirp4netns/issues])
 AC_CONFIG_SRCDIR([main.c])
 AC_CONFIG_HEADERS([config.h])
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.69])
-AC_INIT([slirp4netns], [1.0.0+dev], [https://github.com/rootless-containers/slirp4netns/issues])
+AC_INIT([slirp4netns], [1.0.1], [https://github.com/rootless-containers/slirp4netns/issues])
 AC_CONFIG_SRCDIR([main.c])
 AC_CONFIG_HEADERS([config.h])
 


### PR DESCRIPTION
Updated static binary artifact to use libslirp v4.3.0: https://gitlab.freedesktop.org/slirp/libslirp/-/blob/v4.3.0/CHANGELOG.md

Also updated to use CentOS 7 as the build environment.
Fix #196 