### PR TITLE
Support v2 and v3 options from libslirp

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -5,7 +5,7 @@ AM_CFLAGS = @GLIB_CFLAGS@ @SLIRP_CFLAGS@ @LIBCAP_CFLAGS@ @LIBSECCOMP_CFLAGS@
 noinst_LIBRARIES = libparson.a
 
 AM_TESTS_ENVIRONMENT = PATH="$(abs_top_builddir):$(PATH)"
-TESTS = tests/test-slirp4netns.sh tests/test-slirp4netns-configure.sh tests/test-slirp4netns-exit-fd.sh tests/test-slirp4netns-ready-fd.sh tests/test-slirp4netns-api-socket.sh tests/test-slirp4netns-disable-host-loopback.sh tests/test-slirp4netns-cidr.sh
+TESTS = tests/test-slirp4netns.sh tests/test-slirp4netns-configure.sh tests/test-slirp4netns-exit-fd.sh tests/test-slirp4netns-ready-fd.sh tests/test-slirp4netns-api-socket.sh tests/test-slirp4netns-disable-host-loopback.sh tests/test-slirp4netns-cidr.sh tests/test-slirp4netns-outbound-addr.sh tests/test-slirp4netns-disable-dns.sh
 
 EXTRA_DIST = \
 	slirp4netns.1.md \

--- a/slirp4netns.1.md
+++ b/slirp4netns.1.md
@@ -75,11 +75,27 @@ the capabilities except `CAP_NET_BIND_SERVICE` are dropped.
 enable **seccomp(2)** to limit syscalls.
 Typically used in conjunction with **--enable-sandbox**.
 
+**--outbound-addr=IPv4** (since v1.1.0, EXPERIMENTAL)
+specify outbound ipv4 address slirp should bind to
+
+**--outbound-addr=INTERFACE** (since v1.1.0, EXPERIMENTAL)
+specify outbound interface slirp should bind to (ipv4 traffic only)
+
+**--outbound-addr=IPv6** (since v1.1.0, EXPERIMENTAL)
+specify outbound ipv6 address slirp should bind to
+
+**--outbound-addr6=INTERFACE** (since v1.1.0, EXPERIMENTAL)
+specify outbound interface slirp should bind to (ipv6 traffic only)
+
+**--disable-dns** (since v1.1.0)
+disable built-in DNS (10.0.2.3 by default)
+
 **-h**, **--help** (since v0.2.0)
 show help and exit
 
 **-v**, **--version** (since v0.2.0)
 show version and exit
+
 
 # EXAMPLE
 
@@ -213,6 +229,19 @@ Currently, the **netns-type=TYPE** argument supports **path** or **pid** args wi
 Additionally, a **--userns-path=PATH** argument can be included to override any user namespace path defaults
 ```console
 $ slirp4netns --netns-type=path --userns-path=/path/to/userns /path/to/netns tap0
+```
+
+# OUTBOUND ADDRESSES 
+A user can defined preferred outbound ipv4 and ipv6 address in multi IP scenarios. 
+
+```console
+$ slirp4netns --outbound-addr=10.2.2.10 --outbound-addr6=fe80::10 ...
+```
+
+Optionally you can use interface names instead of ip addresses. 
+
+```console
+$ slirp4netns --outbound-addr=eth0 --outbound-addr6=eth0 ...
 ```
 
 # BUGS

--- a/slirp4netns.c
+++ b/slirp4netns.c
@@ -275,6 +275,24 @@ Slirp *create_slirp(void *opaque, struct slirp4netns_config *s4nn)
     cfg.if_mtu = s4nn->mtu;
     cfg.if_mru = s4nn->mtu;
     cfg.disable_host_loopback = s4nn->disable_host_loopback;
+#if SLIRP_CONFIG_VERSION_MAX >= 2
+    cfg.outbound_addr = NULL;
+    cfg.outbound_addr6 = NULL;
+    if (s4nn->enable_outbound_addr) {
+        cfg.version = 2;
+        cfg.outbound_addr = &s4nn->outbound_addr;
+    }
+    if (s4nn->enable_outbound_addr6) {
+        cfg.version = 2;
+        cfg.outbound_addr6 = &s4nn->outbound_addr6;
+    }
+#endif
+#if SLIRP_CONFIG_VERSION_MAX >= 3
+    if (s4nn->disable_dns) {
+        cfg.version = 3;
+        cfg.disable_dns = true;
+    }
+#endif
     slirp = slirp_new(&cfg, &libslirp_cb, opaque);
     if (slirp == NULL) {
         fprintf(stderr, "slirp_new failed\n");

--- a/slirp4netns.h
+++ b/slirp4netns.h
@@ -1,21 +1,32 @@
 /* SPDX-License-Identifier: GPL-2.0-or-later */
 #ifndef SLIRP4NETNS_H
-# define SLIRP4NETNS_H
+#define SLIRP4NETNS_H
 #include <arpa/inet.h>
 
 struct slirp4netns_config {
-	unsigned int mtu;
-	struct in_addr vnetwork; // 10.0.2.0
-	struct in_addr vnetmask; // 255.255.255.0
-	struct in_addr vhost; // 10.0.2.2
-	struct in_addr vdhcp_start; // 10.0.2.15
-	struct in_addr vnameserver; // 10.0.2.3
-	struct in_addr recommended_vguest; // 10.0.2.100 (slirp itself is unaware of vguest)
-	bool enable_ipv6;
-	bool disable_host_loopback;
-	bool enable_sandbox;
-	bool enable_seccomp;
+    unsigned int mtu;
+    struct in_addr vnetwork; // 10.0.2.0
+    struct in_addr vnetmask; // 255.255.255.0
+    struct in_addr vhost; // 10.0.2.2
+    struct in_addr vdhcp_start; // 10.0.2.15
+    struct in_addr vnameserver; // 10.0.2.3
+    struct in_addr
+        recommended_vguest; // 10.0.2.100 (slirp itself is unaware of vguest)
+    bool enable_ipv6;
+    bool disable_host_loopback;
+    bool enable_sandbox;
+    bool enable_seccomp;
+#if SLIRP_CONFIG_VERSION_MAX >= 2
+    bool enable_outbound_addr;
+    struct sockaddr_in outbound_addr;
+    bool enable_outbound_addr6;
+    struct sockaddr_in6 outbound_addr6;
+#endif
+#if SLIRP_CONFIG_VERSION_MAX >= 3
+    bool disable_dns;
+#endif
 };
-int do_slirp(int tapfd, int readyfd, int exitfd, const char *api_socket, struct slirp4netns_config *cfg);
+int do_slirp(int tapfd, int readyfd, int exitfd, const char *api_socket,
+             struct slirp4netns_config *cfg);
 
 #endif

--- a/tests/common.sh
+++ b/tests/common.sh
@@ -50,6 +50,18 @@ function wait_for_ping_connectivity {
     done
 }
 
+function wait_for_connectivity {
+    COUNTER=0
+    while [ $COUNTER -lt 40 ]; do
+        if echo "wait_for_connectivity" | nsenter --preserve-credentials -U -n --target=$1 ncat -v $2 $3; then
+            break
+        else
+            sleep 0.5
+        fi
+        let COUNTER=COUNTER+1
+    done
+}
+
 function wait_for_file_content {
     # Wait for a file to get the specified content.
     COUNTER=0

--- a/tests/test-slirp4netns-disable-dns.sh
+++ b/tests/test-slirp4netns-disable-dns.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -xeuo pipefail
+
+SLIRP_CONFIG_VERSION_MAX=$(slirp4netns -v | grep "SLIRP_CONFIG_VERSION_MAX: " | sed 's#SLIRP_CONFIG_VERSION_MAX: \(\)##')
+
+if [ "${SLIRP_CONFIG_VERSION_MAX:-0}" -lt 3 ]; then
+    printf "'--disable-dns' requires SLIRP_CONFIG_VERSION_MAX 3 or newer. Test skipped..."
+    exit 0
+fi
+
+. $(dirname $0)/common.sh
+
+port=53
+unshare -r -n sleep infinity &
+child=$!
+
+wait_for_network_namespace $child
+
+mtu=${MTU:=1500}
+slirp4netns -c --mtu $mtu --disable-dns $child tun11 &
+slirp_pid=$!
+
+wait_for_network_device $child tun11
+# ping to 10.0.2.2
+wait_for_ping_connectivity $child 10.0.2.2
+
+function cleanup() {
+    kill -9 $child $slirp_pid
+}
+trap cleanup EXIT
+
+set +e
+err=$(echo "should fail" | nsenter --preserve-credentials -U -n --target=$child ncat -v 10.0.2.3 $port 2>&1)
+set -e
+echo $err | grep "Connection timed out"

--- a/tests/test-slirp4netns-outbound-addr.sh
+++ b/tests/test-slirp4netns-outbound-addr.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+set -xeuo pipefail
+
+SLIRP_CONFIG_VERSION_MAX=$(slirp4netns -v | grep "SLIRP_CONFIG_VERSION_MAX: " | sed 's#SLIRP_CONFIG_VERSION_MAX: \(\)##')
+
+if [ "${SLIRP_CONFIG_VERSION_MAX:-0}" -lt 2 ]; then
+    printf "'--disable-dns' requires SLIRP_CONFIG_VERSION_MAX 2 or newer. Test skipped..."
+    exit 0
+fi
+
+. $(dirname $0)/common.sh
+
+IPv4_1="127.0.0.1"
+IPv4_2=$(ip a | sed -En 's/127.0.0.1//;s/.*inet (addr:)?(([0-9]*\.){3}[0-9]*).*/\2/p' | head -n 1)
+
+# For future ipv6 tests
+#IPv6_1="::1"
+#IPv6_2=$(ip a | sed -En 's/::1\/128//;s/.*inet6 (addr:)?([^ ]*)\/.*$/\2/p' | head -n 1)
+
+function cleanup() {
+    rm -rf ncat.log
+    kill -9 $child $slirp_pid || exit 0
+}
+trap cleanup EXIT
+
+port=12122
+mtu=${MTU:=1500}
+
+IPs=("$IPv4_1" "$IPv4_2")
+for ip in "${IPs[@]}"; do
+    ncat -l $port -v >ncat.log 2>&1 &
+    ncat1=$!
+
+    unshare -r -n sleep infinity &
+    child=$!
+
+    wait_for_network_namespace $child
+
+    slirp4netns -c --mtu $mtu --outbound-addr="$ip" $child tun11 &
+    slirp_pid=$!
+
+    wait_for_network_device $child tun11
+
+    wait_for_connectivity $child 10.0.2.2 $port
+
+    wait_process_exits $ncat1
+    if ! grep "$ip" ncat.log; then
+        printf "%s not found in ncat.log" "$ip"
+        exit 1
+    fi
+    cleanup
+    let port=port+1
+done


### PR DESCRIPTION
Hi, 

This is first draft of changes providing support for configuration v2 and v3 of libslirp.

Fixes #173 

@AkihiroSuda please let me know your thoughts on this. I am not sure about organization of some parts.
E.g.: 
- is it ok to parse outbound addresses in slirp4netns_config_from_options
~~- if we want to print configured outbound address on slirp setup, is it ok to pass original `char *` outbound_addr/6 to `parent` function or is there better way ? (this is not implemented yet)~~