### PR TITLE
v1.1.0-beta.2

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.69])
-AC_INIT([slirp4netns], [1.1.0-beta.2], [https://github.com/rootless-containers/slirp4netns/issues])
+AC_INIT([slirp4netns], [1.1.0-beta.2+dev], [https://github.com/rootless-containers/slirp4netns/issues])
 AC_CONFIG_SRCDIR([main.c])
 AC_CONFIG_HEADERS([config.h])
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.69])
-AC_INIT([slirp4netns], [1.1.0-beta.1+dev], [https://github.com/rootless-containers/slirp4netns/issues])
+AC_INIT([slirp4netns], [1.1.0-beta.2], [https://github.com/rootless-containers/slirp4netns/issues])
 AC_CONFIG_SRCDIR([main.c])
 AC_CONFIG_HEADERS([config.h])
 


### PR DESCRIPTION
Notable changes since v1.0.1:
* Support `--outbound-addr`, `--outbound-addr6`, `--disable-dns` (#200, thanks to @5eraph)
* ARM binaries are now available (#202, #203)
* seccomp: install filter for non-native archs as well (#205)