### PR TITLE
Release v1.1.0 + Declare v1.0.x EOL 

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Tools:
 
 Version                        | Status
 -------------------------------|------------------------------------------------------------------------
+v1.1.x                         | :white_check_mark: Active
 v1.0.x                         | :white_check_mark: Active
 v0.4.x                         | :white_check_mark: Active (EOL: Sep 30, 2020)
 v0.3.x                         | :warning: End of Life (Mar 31, 2020)
@@ -63,6 +64,8 @@ $ sudo make install
 * If you set `--prefix` to `$HOME`, you don't need to run `make install` with `sudo`.
 
 ### Install from binary
+
+Pre-built static binaries are available here: https://github.com/rootless-containers/slirp4netns/releases
 
 #### RHEL 8 & [Fedora (28 or later)](https://src.fedoraproject.org/rpms/slirp4netns):
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Tools:
 Version                        | Status
 -------------------------------|------------------------------------------------------------------------
 v1.1.x                         | :white_check_mark: Active
-v1.0.x                         | :white_check_mark: Active
+v1.0.x                         | :warning: End of Life (Jun 2, 2020)
 v0.4.x                         | :white_check_mark: Active (EOL: Sep 30, 2020)
 v0.3.x                         | :warning: End of Life (Mar 31, 2020)
 v0.2.x                         | :warning: End of Life (Aug 30, 2019)

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.69])
-AC_INIT([slirp4netns], [1.1.0-beta.2+dev], [https://github.com/rootless-containers/slirp4netns/issues])
+AC_INIT([slirp4netns], [1.1.0], [https://github.com/rootless-containers/slirp4netns/issues])
 AC_CONFIG_SRCDIR([main.c])
 AC_CONFIG_HEADERS([config.h])
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.69])
-AC_INIT([slirp4netns], [1.1.0], [https://github.com/rootless-containers/slirp4netns/issues])
+AC_INIT([slirp4netns], [1.1.0+dev], [https://github.com/rootless-containers/slirp4netns/issues])
 AC_CONFIG_SRCDIR([main.c])
 AC_CONFIG_HEADERS([config.h])
 


### PR DESCRIPTION
Notable changes since v1.0.1:
* Experimentally support `--outbound-addr`, `--outbound-addr6`, `--disable-dns` (#200, thanks to @5eraph)
* ARM binaries are now available (#202, #203). The binaries are statically linked with libslirp v4.3.0, using Debian 10.
* seccomp (experimental): install filter for non-native archs as well (#205)

---

v1.1.x takes over from v1.0.x immediately, because v1.1.0 didn't introduce any change other than experimental stuffs.

v0.4.x will be still maintained until Sep 30, 2020.