### PR TITLE
update docs (including guide for inter-namespace communication)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,31 @@
 
 slirp4netns provides user-mode networking ("slirp") for unprivileged network namespaces.
 
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+
+- [Motivation](#motivation)
+- [Projects using slirp4netns](#projects-using-slirp4netns)
+- [Maintenance policy](#maintenance-policy)
+- [Quick start](#quick-start)
+  - [Install](#install)
+  - [Usage](#usage)
+- [Manual](#manual)
+- [Benchmarks](#benchmarks)
+  - [iperf3 (netns -> host)](#iperf3-netns---host)
+- [Install from source](#install-from-source)
+- [Acknowledgement](#acknowledgement)
+- [License](#license)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 ## Motivation
 
 Starting with Linux 3.8, unprivileged users can create [`network_namespaces(7)`](http://man7.org/linux/man-pages/man7/network_namespaces.7.html) along with [`user_namespaces(7)`](http://man7.org/linux/man-pages/man7/user_namespaces.7.html).
 However, unprivileged network namespaces had not been very useful, because creating [`veth(4)`](http://man7.org/linux/man-pages/man4/veth.4.html) pairs across the host and network namespaces still requires the root privileges. (i.e. No internet connection)
 
-slirp4netns allows connecting a network namespace to the Internet in a completely unprivileged way, by connecting a TAP device in a network namespace to the usermode TCP/IP stack ("slirp").
+slirp4netns allows connecting a network namespace to the Internet in a completely unprivileged way, by connecting a TAP device in a network namespace to the usermode TCP/IP stack (["slirp"](https://gitlab.freedesktop.org/slirp/libslirp)).
 
 ## Projects using slirp4netns
 
@@ -43,134 +62,63 @@ See https://github.com/rootless-containers/slirp4netns/security/advisories for t
 
 ## Quick start
 
-### Install from source
+### Install
 
-Build dependencies:
-* `glib2-devel` (`libglib2.0-dev`)
-* `libslirp-devel` >= 4.1 (`libslirp-dev`)
-* `libcap-devel` (`libcap-dev`)
-* `libseccomp-devel` (`libseccomp-dev`)
+Statically linked binaries available for x86\_64, aarch64, armv7l, s390x, and ppc64le: https://github.com/rootless-containers/slirp4netns/releases
 
-Install steps:
+Also available as a package on almost all Linux distributions:
+* [RHEL/CentOS (since 7.7 and 8.0)](https://pkgs.org/search/?q=slirp4netns)
+* [Fedora (since 28)](https://src.fedoraproject.org/rpms/slirp4netns)
+* [Arch Linux](https://www.archlinux.org/packages/community/x86_64/slirp4netns/)
+* [openSUSE (since Leap 15.0)](https://build.opensuse.org/package/show/openSUSE%3AFactory/slirp4netns)
+* [SUSE Linux Enterprise (since 15)](https://build.opensuse.org/package/show/devel%3Akubic/slirp4netns)
+* [Debian GNU/Linux (since 10.0)](https://packages.debian.org/buster/slirp4netns) 
+* [Ubuntu (since 19.04)](https://packages.ubuntu.com/search?keywords=slirp4netns)
+* [NixOS](https://github.com/NixOS/nixpkgs/tree/master/pkgs/tools/networking/slirp4netns)
+* [Gentoo Linux](https://packages.gentoo.org/packages/app-emulation/slirp4netns)
+* [Slackware](https://git.slackbuilds.org/slackbuilds/tree/network/slirp4netns)
+* [Void Linux](https://github.com/void-linux/void-packages/tree/master/srcpkgs/slirp4netns)
+* [Alpine Linux (edge)](https://pkgs.alpinelinux.org/package/edge/testing/x86/slirp4netns)
 
-```console
-$ ./autogen.sh
-$ ./configure --prefix=/usr
-$ make
-$ sudo make install
-```
-
-* To build `slirp4netns` as a static binary, please run `./configure` with `LDFLAGS=-static`.
-* If you set `--prefix` to `$HOME`, you don't need to run `make install` with `sudo`.
-
-### Install from binary
-
-Pre-built static binaries are available here: https://github.com/rootless-containers/slirp4netns/releases
-
-#### RHEL 8 & [Fedora (28 or later)](https://src.fedoraproject.org/rpms/slirp4netns):
+e.g.
 
 ```console
-$ sudo dnf install slirp4netns
+$ sudo apt-get install slirp4netns
 ```
 
-#### RHEL/CentOS 7.7
-
-```console
-$ sudo yum install slirp4netns
-```
-
-#### [RHEL/CentOS 7.6](https://copr.fedorainfracloud.org/coprs/vbatts/shadow-utils-newxidmap/)
-
-```console
-$ sudo curl -o /etc/yum.repos.d/vbatts-shadow-utils-newxidmap-epel-7.repo https://copr.fedorainfracloud.org/coprs/vbatts/shadow-utils-newxidmap/repo/epel-7/vbatts-shadow-utils-newxidmap-epel-7.repo
-$ sudo yum install slirp4netns
-```
-
-You might need to enable user namespaces manually:
-```console
-$ sudo sh -c 'echo "user.max_user_namespaces=28633" > /etc/sysctl.d/userns.conf'
-$ sudo sysctl -p /etc/sysctl.d/userns.conf
-```
-
-#### [Arch Linux](https://www.archlinux.org/packages/community/x86_64/slirp4netns/):
-
-```console
-$ sudo pacman -S slirp4netns
-```
-
-You might need to enable user namespaces manually:
-```console
-$ sudo sh -c "echo 1 > /proc/sys/kernel/unprivileged_userns_clone"
-```
-
-#### [openSUSE Tumbleweed](https://build.opensuse.org/package/show/openSUSE%3AFactory/slirp4netns)
-
-```console
-$ sudo zypper install slirp4netns
-```
-
-#### [openSUSE Leap 15.0](https://build.opensuse.org/package/show/devel%3Akubic/slirp4netns)
-
-```console
-$ sudo zypper addrepo --refresh http://download.opensuse.org/repositories/devel:/kubic/openSUSE_Leap_15.0/devel:kubic.repo
-$ sudo zypper install slirp4netns
-```
-
-#### [SUSE Linux Enterprise 15](https://build.opensuse.org/package/show/devel%3Akubic/slirp4netns)
-
-```console
-$ sudo zypper addrepo --refresh http://download.opensuse.org/repositories/devel:/kubic/SLE_15/devel:kubic.repo
-$ sudo zypper install slirp4netns
-```
-
-#### [Debian GNU/Linux (10 or later)](https://packages.debian.org/buster/slirp4netns) & [Ubuntu (19.04 or later)](https://packages.ubuntu.com/search?keywords=slirp4netns)
-
-```console
-$ sudo apt install slirp4netns
-```
-
-#### [NixOS](https://github.com/NixOS/nixpkgs/tree/master/pkgs/tools/networking/slirp4netns)
-
-```console
-$ nix-env -i slirp4netns
-```
-
-#### [Gentoo Linux](https://packages.gentoo.org/packages/app-emulation/slirp4netns)
-
-```console
-$ sudo emerge app-emulation/slirp4netns
-```
-
-#### [Slackware](https://git.slackbuilds.org/slackbuilds/tree/network/slirp4netns)
-
-```console
-$ sudo sbopkg -i slirp4netns
-```
-
-#### [Void Linux](https://github.com/void-linux/void-packages/tree/master/srcpkgs/slirp4netns)
-
-```console
-$ sudo xbps-install slirp4netns
-```
+To install slirp4netns from the source, see [Install from source](#install-from-source).
 
 ### Usage
 
-Terminal 1: Create user/network/mount namespaces
+**Terminal 1**: Create user/network/mount namespaces
+
 ```console
-$ unshare --user --map-root-user --net --mount
-unshared$ echo $$ > /tmp/pid
+(host)$ unshare --user --map-root-user --net --mount
+(namespace)$ echo $$ > /tmp/pid
 ```
 
-Terminal 2: Start slirp4netns
+In this documentation, we use `(host)$` as the prompt of the host shell, `(namespace)$` as the prompt of the shell running in the namespaces.
+
+If `unshare` fails, try the following commands (known to be needed on Debian, Arch, and old CentOS 7.X):
+
 ```console
-$ slirp4netns --configure --mtu=65520 --disable-host-loopback $(cat /tmp/pid) tap0
+(host)$ sudo sh -c 'echo "user.max_user_namespaces=28633" >> /etc/sysctl.d/userns.conf'
+(host)$ [ -f /proc/sys/kernel/unprivileged_serns_clone ] && sudo sh -c 'echo "kernel.unprivileged_userns_clone=1" >> /etc/sysctl.d/userns.conf'
+(host)$ sudo sysctl --system
+```
+
+**Terminal 2**: Start slirp4netns
+
+```console
+(host)$ slirp4netns --configure --mtu=65520 --disable-host-loopback $(cat /tmp/pid) tap0
 starting slirp, MTU=65520
 ...
 ```
 
-Terminal 1: Make sure the `tap0` is configured and connected to the Internet
+**Terminal 1**: Make sure the `tap0` is configured and connected to the Internet
+
 ```console
-unshared$ ip a
+(namespace)$ ip a
 1: lo: <LOOPBACK> mtu 65536 qdisc noop state DOWN group default qlen 1000
     link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
 3: tap0: <BROADCAST,UP,LOWER_UP> mtu 65520 qdisc fq_codel state UNKNOWN group default qlen 1000
@@ -179,12 +127,25 @@ unshared$ ip a
        valid_lft forever preferred_lft forever
     inet6 fe80::c028:cff:fe0e:2906/64 scope link 
        valid_lft forever preferred_lft forever
-unshared$ echo "nameserver 10.0.2.3" > /tmp/resolv.conf
-unshared$ mount --bind /tmp/resolv.conf /etc/resolv.conf
-unshared$ curl https://example.com
+(namespace)$ echo "nameserver 10.0.2.3" > /tmp/resolv.conf
+(namespace)$ mount --bind /tmp/resolv.conf /etc/resolv.conf
+(namespace)$ curl https://example.com
 ```
 
-See [`slirp4netns.1.md`](slirp4netns.1.md) for further information.
+## Manual
+
+Manual: [`slirp4netns.1.md`](slirp4netns.1.md)
+
+* [Description](./slirp4netns.1.md#description)
+* [Options](./slirp4netns.1.md#options)
+* [Example](./slirp4netns.1.md#example)
+* [Routing ping packets](./slirp4netns.1.md#routing-ping-packets)
+* [API socket](./slirp4netns.1.md#api-socket)
+* [Defined namespace paths](./slirp4netns.1.md#defined-namespace-paths)
+* [Outbound addresses](./slirp4netns.1.md#outbound-addresses)
+* [Inter-namespace communication](./slirp4netns.1.md#inter-namespace-communication)
+* [Inter-host communication](./slirp4netns.1.md#inter-host-communication)
+* [Bugs](./slirp4netns.1.md#bugs)
 
 ## Benchmarks
 
@@ -200,7 +161,34 @@ slirp4netns    | 1.07 Gbps  | 2.78 Gbps  |  4.55 Gbps  |  9.21 Gbps
 
 slirp4netns is faster than [vde_plug](https://github.com/rd235/vdeplug_slirp) and [VPNKit](https://github.com/moby/vpnkit) because slirp4netns is optimized to avoid copying packets across the namespaces.
 
-The latest revision of slirp4netns is regularly benchmarked (`make benchmark`) on Travis: https://travis-ci.org/rootless-containers/slirp4netns
+The latest revision of slirp4netns is regularly benchmarked (`make benchmark`) on [CI](https://github.com/rootless-containers/slirp4netns/actions?query=workflow%3AMain).
+
+## Install from source
+
+Build dependencies (`apt-get`):
+
+```console
+$ sudo apt-get install libglib2.0-dev libslirp-dev libcap-dev libseccomp-dev
+```
+
+Build dependencies (`dnf`):
+
+```console
+$ sudo dnf install glib2-devel libslirp-devel libcap-devel libseccomp-devel
+```
+
+Installation steps:
+
+```console
+$ ./autogen.sh
+$ ./configure --prefix=/usr
+$ make
+$ sudo make install
+```
+
+* [libslirp](https://gitlab.freedesktop.org/slirp/libslirp) needs to be v4.1.0 or later.
+* To build `slirp4netns` as a static binary, run `./configure` with `LDFLAGS=-static`.
+* If you set `--prefix` to `$HOME`, you don't need to run `make install` with `sudo`.
 
 ## Acknowledgement
 See [`vendor/README.md`](./vendor/README.md).

--- a/slirp4netns.1
+++ b/slirp4netns.1
@@ -1,5 +1,5 @@
 .nh
-.TH SLIRP4NETNS 1 "March 2020" "Rootless Containers" "User Commands"
+.TH SLIRP4NETNS 1 "July 2020" "Rootless Containers" "User Commands"
 
 .SH NAME
 .PP
@@ -16,7 +16,7 @@ slirp4netns [OPTION]... PID|PATH TAPNAME
 slirp4netns provides user\-mode networking ("slirp") for network namespaces.
 
 .PP
-Unlike \fBveth\fP(4), slirp4netns does not require the root privileges on the host.
+Unlike \fB\fCveth(4)\fR, slirp4netns does not require the root privileges on the host.
 
 .PP
 Default configuration:
@@ -42,118 +42,135 @@ IPv6 DNS:          fd00::3
 
 .SH OPTIONS
 .PP
-\fB\-c\fP, \fB\-\-configure\fP
+\fB\fC\-c\fR, \fB\fC\-\-configure\fR
 bring up the TAP interface. IP will be set to 10.0.2.100 (network address + 100) by default. IPv6 will be set to a random address.
-Starting with v0.4.0, the loopback interface (\fBlo\fP) is brought up as well.
+Starting with v0.4.0, the loopback interface (\fB\fClo\fR) is brought up as well.
 
 .PP
-\fB\-e\fP, \fB\-\-exit\-fd=FD\fP
+\fB\fC\-e\fR, \fB\fC\-\-exit\-fd=FD\fR
 specify the FD for terminating slirp4netns.
-When the FD is specified, slirp4netns exits when a \fBpoll(2)\fP event happens on the FD.
+When the FD is specified, slirp4netns exits when a \fB\fCpoll(2)\fR event happens on the FD.
 
 .PP
-\fB\-r\fP, \fB\-\-ready\-fd=FD\fP
+\fB\fC\-r\fR, \fB\fC\-\-ready\-fd=FD\fR
 specify the FD to write to when the initialization steps are finished.
-When the FD is specified, slirp4netns writes \fB"1"\fP to the FD and close the FD.
-Prior to v0.4.0, the FD was written after the network configuration (\fB\-c\fP)
-but before the API socket configuration (\fB\-a\fP).
+When the FD is specified, slirp4netns writes \fB\fC"1"\fR to the FD and close the FD.
+Prior to v0.4.0, the FD was written after the network configuration (\fB\fC\-c\fR)
+but before the API socket configuration (\fB\fC\-a\fR).
 
 .PP
-\fB\-m\fP, \fB\-\-mtu=MTU\fP (since v0.2.0)
+\fB\fC\-m\fR, \fB\fC\-\-mtu=MTU\fR (since v0.2.0)
 specify MTU (max=65521).
 
 .PP
-\fB\-6\fP, \fB\-\-enable\-ipv6\fP (since v0.2.0, EXPERIMENTAL)
+\fB\fC\-6\fR, \fB\fC\-\-enable\-ipv6\fR (since v0.2.0, EXPERIMENTAL)
 enable IPv6
 
 .PP
-\fB\-a\fP, \fB\-\-api\-socket\fP (since v0.3.0)
+\fB\fC\-a\fR, \fB\fC\-\-api\-socket\fR (since v0.3.0)
 API socket path
 
 .PP
-\fB\-\-cidr\fP (since v0.3.0)
+\fB\fC\-\-cidr\fR (since v0.3.0)
 specify CIDR, e.g. 10.0.2.0/24
 
 .PP
-\fB\-\-disable\-host\-loopback\fP (since v0.3.0)
+\fB\fC\-\-disable\-host\-loopback\fR (since v0.3.0)
 prohibit connecting to 127.0.0.1:* on the host namespace
 
 .PP
-\fB\-\-netns\-type=TYPE\fP (since v0.4.0)
+\fB\fC\-\-netns\-type=TYPE\fR (since v0.4.0)
 specify network namespace type ([path|pid], default=pid)
 
 .PP
-\fB\-\-userns\-path=PATH\fP (since v0.4.0)
+\fB\fC\-\-userns\-path=PATH\fR (since v0.4.0)
 specify user namespace path
 
 .PP
-\fB\-\-enable\-sandbox\fP (since v0.4.0)
+\fB\fC\-\-enable\-sandbox\fR (since v0.4.0)
 enter the user namespace and create a new mount namespace where only /etc and
 /run are mounted from the host.
 
 .PP
-Requires \fB/etc/resolv.conf\fP not to be a symlink to a file outside /etc and /run.
+Requires \fB\fC/etc/resolv.conf\fR not to be a symlink to a file outside /etc and /run.
 
 .PP
 When running as the root, the process does not enter the user namespace but all
 the capabilities except \fB\fCCAP\_NET\_BIND\_SERVICE\fR are dropped.
 
 .PP
-\fB\-\-enable\-seccomp\fP (since v0.4.0, EXPERIMENTAL)
-enable \fBseccomp(2)\fP to limit syscalls.
-Typically used in conjunction with \fB\-\-enable\-sandbox\fP\&.
+\fB\fC\-\-enable\-seccomp\fR (since v0.4.0, EXPERIMENTAL)
+enable \fB\fCseccomp(2)\fR to limit syscalls.
+Typically used in conjunction with \fB\fC\-\-enable\-sandbox\fR\&.
 
 .PP
-\fB\-\-outbound\-addr=IPv4\fP (since v1.1.0, EXPERIMENTAL)
+\fB\fC\-\-outbound\-addr=IPv4\fR (since v1.1.0, EXPERIMENTAL)
 specify outbound ipv4 address slirp should bind to
 
 .PP
-\fB\-\-outbound\-addr=INTERFACE\fP (since v1.1.0, EXPERIMENTAL)
+\fB\fC\-\-outbound\-addr=INTERFACE\fR (since v1.1.0, EXPERIMENTAL)
 specify outbound interface slirp should bind to (ipv4 traffic only)
 
 .PP
-\fB\-\-outbound\-addr=IPv6\fP (since v1.1.0, EXPERIMENTAL)
+\fB\fC\-\-outbound\-addr=IPv6\fR (since v1.1.0, EXPERIMENTAL)
 specify outbound ipv6 address slirp should bind to
 
 .PP
-\fB\-\-outbound\-addr6=INTERFACE\fP (since v1.1.0, EXPERIMENTAL)
+\fB\fC\-\-outbound\-addr6=INTERFACE\fR (since v1.1.0, EXPERIMENTAL)
 specify outbound interface slirp should bind to (ipv6 traffic only)
 
 .PP
-\fB\-\-disable\-dns\fP (since v1.1.0)
+\fB\fC\-\-disable\-dns\fR (since v1.1.0)
 disable built\-in DNS (10.0.2.3 by default)
 
 .PP
-\fB\-h\fP, \fB\-\-help\fP (since v0.2.0)
+\fB\fC\-h\fR, \fB\fC\-\-help\fR (since v0.2.0)
 show help and exit
 
 .PP
-\fB\-v\fP, \fB\-\-version\fP (since v0.2.0)
+\fB\fC\-v\fR, \fB\fC\-\-version\fR (since v0.2.0)
 show version and exit
 
 
 .SH EXAMPLE
 .PP
-Terminal 1: Create user/network/mount namespaces
+\fBTerminal 1\fP: Create user/network/mount namespaces
 
 .PP
 .RS
 
 .nf
-$ unshare \-\-user \-\-map\-root\-user \-\-net \-\-mount
-unshared$ echo $$ > /tmp/pid
+(host)$ unshare \-\-user \-\-map\-root\-user \-\-net \-\-mount
+(namespace)$ echo $$ > /tmp/pid
 
 .fi
 .RE
 
 .PP
-Terminal 2: Start slirp4netns
+In this documentation, we use \fB\fC(host)$\fR as the prompt of the host shell, \fB\fC(namespace)$\fR as the prompt of the shell running in the namespaces.
+
+.PP
+If \fB\fCunshare\fR fails, try the following commands (known to be needed on Debian, Arch, and old CentOS 7.X):
 
 .PP
 .RS
 
 .nf
-$ slirp4netns \-\-configure \-\-mtu=65520 $(cat /tmp/pid) tap0
+(host)$ sudo sh \-c 'echo "user.max\_user\_namespaces=28633" >> /etc/sysctl.d/userns.conf'
+(host)$ [ \-f /proc/sys/kernel/unprivileged\_serns\_clone ] \&\& sudo sh \-c 'echo "kernel.unprivileged\_userns\_clone=1" >> /etc/sysctl.d/userns.conf'
+(host)$ sudo sysctl \-\-system
+
+.fi
+.RE
+
+.PP
+\fBTerminal 2\fP: Start slirp4netns
+
+.PP
+.RS
+
+.nf
+(host)$ slirp4netns \-\-configure \-\-mtu=65520 $(cat /tmp/pid) tap0
 starting slirp, MTU=65520
 ...
 
@@ -161,13 +178,13 @@ starting slirp, MTU=65520
 .RE
 
 .PP
-Terminal 1: Make sure \fBtap0\fP is configured and connected to the Internet
+\fBTerminal 1\fP: Make sure \fB\fCtap0\fR is configured and connected to the Internet
 
 .PP
 .RS
 
 .nf
-unshared$ ip a
+(namespace)$ ip a
 1: lo: <LOOPBACK> mtu 65536 qdisc noop state DOWN group default qlen 1000
     link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
 3: tap0: <BROADCAST,UP,LOWER\_UP> mtu 65520 qdisc fq\_codel state UNKNOWN group default qlen 1000
@@ -176,39 +193,52 @@ unshared$ ip a
        valid\_lft forever preferred\_lft forever
     inet6 fe80::c028:cff:fe0e:2906/64 scope link 
        valid\_lft forever preferred\_lft forever
-unshared$ echo "nameserver 10.0.2.3" > /tmp/resolv.conf
-unshared$ mount \-\-bind /tmp/resolv.conf /etc/resolv.conf
-unshared$ curl https://example.com
+(namespace)$ echo "nameserver 10.0.2.3" > /tmp/resolv.conf
+(namespace)$ mount \-\-bind /tmp/resolv.conf /etc/resolv.conf
+(namespace)$ curl https://example.com
 
 .fi
 .RE
 
 .PP
-Bind\-mounting \fB/etc/resolv.conf\fP is only needed when \fB/etc/resolv.conf\fP on
-the host refers to loopback addresses (\fB127.0.0.X\fP, typically because of
-\fBdnsmasq\fP(8) or \fBsystemd\-resolved.service\fP(8)) that cannot be accessed from
-the namespace.
+Bind\-mounting \fB\fC/etc/resolv.conf\fR is only needed when \fB\fC/etc/resolv.conf\fR on
+the host refers to loopback addresses (\fB\fC127.0.0.X\fR, typically \fB\fCdnsmasq(8)\fR
+or \fB\fCsystemd\-resolved.service(8)\fR) that cannot be accessed from the namespace.
 
 .PP
-If your \fB/etc/resolv.conf\fP on the host is managed by \fBnetworkmanager\fP(8)
-or \fBsystemd\-resolved.service\fP(8), you might need to mount a new filesystem on
-\fB/etc\fP instead, so as to prevent the new \fB/etc/resolv.conf\fP from being
-unmounted unexpectedly when \fB/etc/resolv.conf\fP on the host is regenerated.
+If your \fB\fC/etc/resolv.conf\fR on the host is managed by \fB\fCnetworkmanager(8)\fR
+or \fB\fCsystemd\-resolved.service(8)\fR, you might need to mount a new filesystem on
+\fB\fC/etc\fR instead, so as to prevent the new \fB\fC/etc/resolv.conf\fR from being
+unmounted unexpectedly when \fB\fC/etc/resolv.conf\fR on the host is regenerated.
 
 .PP
 .RS
 
 .nf
-unshared$ mkdir /tmp/a /tmp/b
-unshared$ mount \-\-rbind /etc /tmp/a
-unshared$ mount \-\-rbind /tmp/b /etc
-unshared$ mkdir /etc/.ro
-unshared$ mount \-\-move /tmp/a /etc/.ro
-unshared$ cd /etc
-unshared$ for f in .ro/*; do ln \-s $f $(basename $f); done
-unshared$ rm resolv.conf
-unshared$ echo "nameserver 10.0.2.3" > /tmp/resolv.conf
-unshared$ curl https://example.com
+(namespace)$ mkdir /tmp/a /tmp/b
+(namespace)$ mount \-\-rbind /etc /tmp/a
+(namespace)$ mount \-\-rbind /tmp/b /etc
+(namespace)$ mkdir /etc/.ro
+(namespace)$ mount \-\-move /tmp/a /etc/.ro
+(namespace)$ cd /etc
+(namespace)$ for f in .ro/*; do ln \-s $f $(basename $f); done
+(namespace)$ rm resolv.conf
+(namespace)$ echo "nameserver 10.0.2.3" > resolv.conf
+(namespace)$ curl https://example.com
+
+.fi
+.RE
+
+.PP
+These steps can be simplified with \fB\fCrootlesskit \-\-copy\-up=/etc\fR if \fB\fCrootlesskit\fR is installed:
+
+.PP
+.RS
+
+.nf
+(host)$ rootlesskit \-\-net=slirp4netns \-\-copy\-up=/etc bash
+(namespace)$ cat /etc/resolv.conf
+nameserver 10.0.2.3
 
 .fi
 .RE
@@ -216,8 +246,7 @@ unshared$ curl https://example.com
 
 .SH ROUTING PING PACKETS
 .PP
-To route ping packets, you need to set up \fBnet.ipv4.ping\_group\_range\fP properly
-as the root.
+To route ping packets, you may need to set up \fB\fCnet.ipv4.ping\_group\_range\fR properly as the root.
 
 .PP
 e.g.
@@ -226,7 +255,8 @@ e.g.
 .RS
 
 .nf
-$ sudo sh \-c "echo 0   2147483647  > /proc/sys/net/ipv4/ping\_group\_range"
+(host)$ sudo sh \-c 'echo "net.ipv4.ping\_group\_range=0   2147483647" > /etc/sysctl.d/ping\_group\_range.conf'
+(host)$ sudo sysctl \-\-system
 
 .fi
 .RE
@@ -234,19 +264,20 @@ $ sudo sh \-c "echo 0   2147483647  > /proc/sys/net/ipv4/ping\_group\_range"
 
 .SH FILTERING CONNECTIONS
 .PP
-By default, ports listening on \fBINADDR\_LOOPBACK\fP (\fB127.0.0.1\fP) on the host are accessible from the child namespace via the gateway (default: \fB10.0.2.2\fP).
-\fB\-\-disable\-host\-loopback\fP can be used to prohibit connecting to \fBINADDR\_LOOPBACK\fP on the host.
+By default, ports listening on \fB\fCINADDR\_LOOPBACK\fR (\fB\fC127.0.0.1\fR) on the host are accessible from the child namespace via the gateway (default: \fB\fC10.0.2.2\fR).
+\fB\fC\-\-disable\-host\-loopback\fR can be used to prohibit connecting to \fB\fCINADDR\_LOOPBACK\fR on the host.
 
 .PP
-However, a host loopback address might be still accessible via the built\-in DNS (default: \fB10.0.2.3\fP) if \fB\fC/etc/resolv.conf\fR on the host refers to a loopback address.
+However, a host loopback address might be still accessible via the built\-in DNS (default: \fB\fC10.0.2.3\fR) if \fB\fC/etc/resolv.conf\fR on the host refers to a loopback address.
 You may want to set up iptables for limiting access to the built\-in DNS in such a case.
 
 .PP
 .RS
 
 .nf
-unshared$ iptables \-A OUTPUT \-d 10.0.2.3 \-p udp \-\-dport 53 \-j ACCEPT
-unshared$ iptables \-A OUTPUT \-d 10.0.2.3 \-j DROP
+(host)$ nsenter \-t $(cat /tmp/pid) \-U \-n
+(namespace)$ iptables \-A OUTPUT \-d 10.0.2.3 \-p udp \-\-dport 53 \-j ACCEPT
+(namespace)$ iptables \-A OUTPUT \-d 10.0.2.3 \-j DROP
 
 .fi
 .RE
@@ -260,55 +291,55 @@ slirp4netns can provide QMP\-like API server over an UNIX socket file:
 .RS
 
 .nf
-$ slirp4netns \-\-api\-socket /tmp/slirp4netns.sock ...
+(host)$ slirp4netns \-\-api\-socket /tmp/slirp4netns.sock ...
 
 .fi
 .RE
 
 .PP
-\fBadd\_hostfwd\fP: Expose a port (IPv4 only)
+\fB\fCadd\_hostfwd\fR: Expose a port (IPv4 only)
 
 .PP
 .RS
 
 .nf
-$ json='{"execute": "add\_hostfwd", "arguments": {"proto": "tcp", "host\_addr": "0.0.0.0", "host\_port": 8080, "guest\_addr": "10.0.2.100", "guest\_port": 80}}'
-$ echo \-n $json | nc \-U /tmp/slirp4netns.sock
-{ "return": {"id": 42}}
+(namespace)$ json='{"execute": "add\_hostfwd", "arguments": {"proto": "tcp", "host\_addr": "0.0.0.0", "host\_port": 8080, "guest\_addr": "10.0.2.100", "guest\_port": 80}}'
+(namespace)$ echo \-n $json | nc \-U /tmp/slirp4netns.sock
+{"return": {"id": 42}}
 
 .fi
 .RE
 
 .PP
-If \fBhost\_addr\fP is not specified, then it defaults to "0.0.0.0".
+If \fB\fChost\_addr\fR is not specified, then it defaults to "0.0.0.0".
 
 .PP
-If \fBguest\_addr\fP is not specified, then it will be set to the default address that corresponds to \-\-configure.
+If \fB\fCguest\_addr\fR is not specified, then it will be set to the default address that corresponds to \fB\fC\-\-configure\fR\&.
 
 .PP
-\fBlist\_hostfwd\fP: List exposed ports
+\fB\fClist\_hostfwd\fR: List exposed ports
 
 .PP
 .RS
 
 .nf
-$ json='{"execute": "list\_hostfwd"}'
-$ echo \-n $json | nc \-U /tmp/slirp4netns.sock
-{ "return": {"entries": [{"id": 42, "proto": "tcp", "host\_addr": "0.0.0.0", "host\_port": 8080, "guest\_addr": "10.0.2.100", "guest\_port": 80}]}}
+(namespace)$ json='{"execute": "list\_hostfwd"}'
+(namespace)$ echo \-n $json | nc \-U /tmp/slirp4netns.sock
+{"return": {"entries": [{"id": 42, "proto": "tcp", "host\_addr": "0.0.0.0", "host\_port": 8080, "guest\_addr": "10.0.2.100", "guest\_port": 80}]}}
 
 .fi
 .RE
 
 .PP
-\fBremove\_hostfwd\fP: Remove an exposed port
+\fB\fCremove\_hostfwd\fR: Remove an exposed port
 
 .PP
 .RS
 
 .nf
-$ json='{"execute": "remove\_hostfwd", "arguments": {"id": 42}}'
-$ echo \-n $json | nc \-U /tmp/slirp4netns.sock
-{ "return": {}}
+(namespace)$ json='{"execute": "remove\_hostfwd", "arguments": {"id": 42}}'
+(namespace)$ echo \-n $json | nc \-U /tmp/slirp4netns.sock
+{"return": {}}
 
 .fi
 .RE
@@ -318,14 +349,14 @@ Remarks:
 
 .RS
 .IP \(bu 2
-Client needs to \fBshutdown(2)\fP the socket with \fBSHUT\_WR\fP after sending every request.
+Client needs to \fB\fCshutdown(2)\fR the socket with \fB\fCSHUT\_WR\fR after sending every request.
 i.e. No support for keep\-alive and timeout.
 .IP \(bu 2
 slirp4netns "stops the world" during processing API requests.
 .IP \(bu 2
 A request must be less than 4096 bytes.
 .IP \(bu 2
-JSON responses may contain \fBerror\fP instead of \fBreturn\fP\&.
+JSON responses may contain \fB\fCerror\fR instead of \fB\fCreturn\fR\&.
 
 .RE
 
@@ -338,22 +369,22 @@ A user can define a network namespace path as opposed to the default process ID:
 .RS
 
 .nf
-$ slirp4netns \-\-netns\-type=path ... /path/to/netns tap0
+(host)$ slirp4netns \-\-netns\-type=path ... /path/to/netns tap0
 
 .fi
 .RE
 
 .PP
-Currently, the \fBnetns\-type=TYPE\fP argument supports \fBpath\fP or \fBpid\fP args with the default being \fBpid\fP\&.
+Currently, the \fB\fCnetns\-type=TYPE\fR argument supports \fB\fCpath\fR or \fB\fCpid\fR args with the default being \fB\fCpid\fR\&.
 
 .PP
-Additionally, a \fB\-\-userns\-path=PATH\fP argument can be included to override any user namespace path defaults
+Additionally, a \fB\fC\-\-userns\-path=PATH\fR argument can be included to override any user namespace path defaults
 
 .PP
 .RS
 
 .nf
-$ slirp4netns \-\-netns\-type=path \-\-userns\-path=/path/to/userns /path/to/netns tap0
+(host)$ slirp4netns \-\-netns\-type=path \-\-userns\-path=/path/to/userns /path/to/netns tap0
 
 .fi
 .RE
@@ -367,7 +398,7 @@ A user can defined preferred outbound ipv4 and ipv6 address in multi IP scenario
 .RS
 
 .nf
-$ slirp4netns \-\-outbound\-addr=10.2.2.10 \-\-outbound\-addr6=fe80::10 ...
+(host)$ slirp4netns \-\-outbound\-addr=10.2.2.10 \-\-outbound\-addr6=fe80::10 ...
 
 .fi
 .RE
@@ -379,26 +410,86 @@ Optionally you can use interface names instead of ip addresses.
 .RS
 
 .nf
-$ slirp4netns \-\-outbound\-addr=eth0 \-\-outbound\-addr6=eth0 ...
+(host)$ slirp4netns \-\-outbound\-addr=eth0 \-\-outbound\-addr6=eth0 ...
 
 .fi
 .RE
 
 
-.SH BUGS
+.SH INTER\-NAMESPACE COMMUNICATION
 .PP
-Kernel 4.20 bumped up the default value of \fB/proc/sys/net/ipv4/tcp\_rmem\fP from 87380 to 131072.
-This is known to slow down slirp4netns port forwarding: \fBhttps://github.com/rootless\-containers/slirp4netns/issues/128\fP\&.
+The easiest way to allow inter\-namespace communication is to nest network namespaces inside the slirp4netns's network namespace.
 
 .PP
-As a workaround, you can adjust the value of \fB/proc/sys/net/ipv4/tcp\_rmem\fP inside the namespace.
+.RS
+
+.nf
+(host)$ nsenter \-t $(cat /tmp/pid) \-U \-n \-m
+(namespace)$ mount \-t tmpfs none /run
+(namespace)$ ip netns add foo
+(namespace)$ ip netns add bar
+(namespace)$ ip link add veth\-foo type veth peer name veth\-bar
+(namespace)$ ip link set veth\-foo netns foo
+(namespace)$ ip link set veth\-bar netns bar
+(namespace)$ ip netns exec foo ip link set veth\-foo name eth0
+(namespace)$ ip netns exec bar ip link set veth\-bar name eth0
+(namespace)$ ip netns exec foo ip link set lo up
+(namespace)$ ip netns exec bar ip link set lo up
+(namespace)$ ip netns exec foo ip link set eth0 up
+(namespace)$ ip netns exec bar ip link set eth0 up
+(namespace)$ ip netns exec foo ip addr add 192.168.42.100/24 dev eth0
+(namespace)$ ip netns exec bar ip addr add 192.168.42.101/24 dev eth0
+(namespace)$ ip netns exec bar ping 192.168.42.100
+
+.fi
+.RE
+
+.PP
+However, this method does not work when you want to allow communication across multiple slirp4netns instances.
+To allow communication across multiple slirp4netns instances, you need to combine another network stack such as
+\fB\fCvde\_plug(1)\fR with slirp4netns.
+
+.PP
+.RS
+
+.nf
+(host)$ vde\_plug \-\-daemon switch:///tmp/switch null://
+(host)$ nsenter \-t $(cat /tmp/pid\-instance0) \-U \-n
+(namespace\-instance0)$ vde\_plug \-\-daemon vde:///tmp/switch tap://vde
+(namespace\-instance0)$ ip link set vde up
+(namespace\-instance0)$ ip addr add 192.168.42.100/24 dev vde
+(namespace\-instance0)$ exit
+(host)$ nsenter \-t $(cat /tmp/pid\-instance1) \-U \-n
+(namespace\-instance1)$ vde\_plug \-\-daemon vde:///tmp/switch tap://vde
+(namespace\-instance1)$ ip link set vde up
+(namespace\-instance1)$ ip addr add 192.168.42.101/24 dev vde
+(namespace\-instance1)$ ping 192.168.42.100
+
+.fi
+.RE
+
+
+.SH INTER\-HOST COMMUNICATION
+.PP
+VXLAN is known to work.
+See Usernetes project for the example of multi\-node rootless Kubernetes cluster with VXLAN: \fB\fChttps://github.com/rootless\-containers/usernetes\fR
+
+
+.SH BUGS
+.PP
+Kernel 4.20 bumped up the default value of \fB\fC/proc/sys/net/ipv4/tcp\_rmem\fR from 87380 to 131072.
+This is known to slow down slirp4netns port forwarding: \fB\fChttps://github.com/rootless\-containers/slirp4netns/issues/128\fR\&.
+
+.PP
+As a workaround, you can adjust the value of \fB\fC/proc/sys/net/ipv4/tcp\_rmem\fR inside the namespace.
 No real root privilege is needed to modify the file since kernel 4.15.
 
 .PP
 .RS
 
 .nf
-unshared$ c=$(cat /proc/sys/net/ipv4/tcp\_rmem); echo $c | sed \-e s/131072/87380/g > /proc/sys/net/ipv4/tcp\_rmem
+(host)$ nsenter \-t $(cat /tmp/pid) \-U \-n \-m
+(namespace)$ c=$(cat /proc/sys/net/ipv4/tcp\_rmem); echo $c | sed \-e s/131072/87380/g > /proc/sys/net/ipv4/tcp\_rmem
 
 .fi
 .RE
@@ -406,9 +497,9 @@ unshared$ c=$(cat /proc/sys/net/ipv4/tcp\_rmem); echo $c | sed \-e s/131072/8738
 
 .SH SEE ALSO
 .PP
-\fBnetwork\_namespaces\fP(7), \fBuser\_namespaces\fP(7), \fBveth\fP(4)
+\fB\fCnetwork\_namespaces(7)\fR, \fB\fCuser\_namespaces(7)\fR, \fB\fCveth(4)\fR
 
 
 .SH AVAILABILITY
 .PP
-The slirp4netns command is available from \fBhttps://github.com/rootless\-containers/slirp4netns\fP under GNU GENERAL PUBLIC LICENSE Version 2 (or later).
+The slirp4netns command is available from \fB\fChttps://github.com/rootless\-containers/slirp4netns\fR under GNU GENERAL PUBLIC LICENSE Version 2 (or later).

--- a/slirp4netns.1.md
+++ b/slirp4netns.1.md
@@ -13,7 +13,7 @@ slirp4netns [OPTION]... PID|PATH TAPNAME
 
 slirp4netns provides user-mode networking ("slirp") for network namespaces.
 
-Unlike **veth**(4), slirp4netns does not require the root privileges on the host.
+Unlike `veth(4)`, slirp4netns does not require the root privileges on the host.
 
 Default configuration:
 
@@ -27,73 +27,73 @@ Default configuration:
 
 # OPTIONS
 
-**-c**, **--configure**
+`-c`, `--configure`
 bring up the TAP interface. IP will be set to 10.0.2.100 (network address + 100) by default. IPv6 will be set to a random address.
-Starting with v0.4.0, the loopback interface (**lo**) is brought up as well.
+Starting with v0.4.0, the loopback interface (`lo`) is brought up as well.
 
-**-e**, **--exit-fd=FD**
+`-e`, `--exit-fd=FD`
 specify the FD for terminating slirp4netns.
-When the FD is specified, slirp4netns exits when a **poll(2)** event happens on the FD.
+When the FD is specified, slirp4netns exits when a `poll(2)` event happens on the FD.
 
-**-r**, **--ready-fd=FD**
+`-r`, `--ready-fd=FD`
 specify the FD to write to when the initialization steps are finished.
-When the FD is specified, slirp4netns writes **"1"** to the FD and close the FD.
-Prior to v0.4.0, the FD was written after the network configuration (**-c**)
-but before the API socket configuration (**-a**).
+When the FD is specified, slirp4netns writes `"1"` to the FD and close the FD.
+Prior to v0.4.0, the FD was written after the network configuration (`-c`)
+but before the API socket configuration (`-a`).
 
-**-m**, **--mtu=MTU** (since v0.2.0)
+`-m`, `--mtu=MTU` (since v0.2.0)
 specify MTU (max=65521).
 
-**-6**, **--enable-ipv6** (since v0.2.0, EXPERIMENTAL)
+`-6`, `--enable-ipv6` (since v0.2.0, EXPERIMENTAL)
 enable IPv6
 
-**-a**, **--api-socket** (since v0.3.0)
+`-a`, `--api-socket` (since v0.3.0)
 API socket path
 
-**--cidr** (since v0.3.0)
+`--cidr` (since v0.3.0)
 specify CIDR, e.g. 10.0.2.0/24
 
-**--disable-host-loopback** (since v0.3.0)
+`--disable-host-loopback` (since v0.3.0)
 prohibit connecting to 127.0.0.1:\* on the host namespace
 
-**--netns-type=TYPE** (since v0.4.0)
+`--netns-type=TYPE` (since v0.4.0)
 specify network namespace type ([path|pid], default=pid)
 
-**--userns-path=PATH** (since v0.4.0)
+`--userns-path=PATH` (since v0.4.0)
 specify user namespace path
 
-**--enable-sandbox** (since v0.4.0)
+`--enable-sandbox` (since v0.4.0)
 enter the user namespace and create a new mount namespace where only /etc and
 /run are mounted from the host.
 
-Requires **/etc/resolv.conf** not to be a symlink to a file outside /etc and /run.
+Requires `/etc/resolv.conf` not to be a symlink to a file outside /etc and /run.
 
 When running as the root, the process does not enter the user namespace but all
 the capabilities except `CAP_NET_BIND_SERVICE` are dropped.
 
-**--enable-seccomp** (since v0.4.0, EXPERIMENTAL)
-enable **seccomp(2)** to limit syscalls.
-Typically used in conjunction with **--enable-sandbox**.
+`--enable-seccomp` (since v0.4.0, EXPERIMENTAL)
+enable `seccomp(2)` to limit syscalls.
+Typically used in conjunction with `--enable-sandbox`.
 
-**--outbound-addr=IPv4** (since v1.1.0, EXPERIMENTAL)
+`--outbound-addr=IPv4` (since v1.1.0, EXPERIMENTAL)
 specify outbound ipv4 address slirp should bind to
 
-**--outbound-addr=INTERFACE** (since v1.1.0, EXPERIMENTAL)
+`--outbound-addr=INTERFACE` (since v1.1.0, EXPERIMENTAL)
 specify outbound interface slirp should bind to (ipv4 traffic only)
 
-**--outbound-addr=IPv6** (since v1.1.0, EXPERIMENTAL)
+`--outbound-addr=IPv6` (since v1.1.0, EXPERIMENTAL)
 specify outbound ipv6 address slirp should bind to
 
-**--outbound-addr6=INTERFACE** (since v1.1.0, EXPERIMENTAL)
+`--outbound-addr6=INTERFACE` (since v1.1.0, EXPERIMENTAL)
 specify outbound interface slirp should bind to (ipv6 traffic only)
 
-**--disable-dns** (since v1.1.0)
+`--disable-dns` (since v1.1.0)
 disable built-in DNS (10.0.2.3 by default)
 
-**-h**, **--help** (since v0.2.0)
+`-h`, `--help` (since v0.2.0)
 show help and exit
 
-**-v**, **--version** (since v0.2.0)
+`-v`, `--version` (since v0.2.0)
 show version and exit
 
 
@@ -124,7 +124,7 @@ starting slirp, MTU=65520
 ...
 ```
 
-**Terminal 1**: Make sure **tap0** is configured and connected to the Internet
+**Terminal 1**: Make sure `tap0` is configured and connected to the Internet
 
 ```console
 (namespace)$ ip a
@@ -141,14 +141,14 @@ starting slirp, MTU=65520
 (namespace)$ curl https://example.com
 ```
 
-Bind-mounting **/etc/resolv.conf** is only needed when **/etc/resolv.conf** on
-the host refers to loopback addresses (**127.0.0.X**, typically **dnsmasq**(8)
-or **systemd-resolved.service**(8)) that cannot be accessed from the namespace.
+Bind-mounting `/etc/resolv.conf` is only needed when `/etc/resolv.conf` on
+the host refers to loopback addresses (`127.0.0.X`, typically `dnsmasq(8)`
+or `systemd-resolved.service(8)`) that cannot be accessed from the namespace.
 
-If your **/etc/resolv.conf** on the host is managed by **networkmanager**(8)
-or **systemd-resolved.service**(8), you might need to mount a new filesystem on
-**/etc** instead, so as to prevent the new **/etc/resolv.conf** from being
-unmounted unexpectedly when **/etc/resolv.conf** on the host is regenerated.
+If your `/etc/resolv.conf` on the host is managed by `networkmanager(8)`
+or `systemd-resolved.service(8)`, you might need to mount a new filesystem on
+`/etc` instead, so as to prevent the new `/etc/resolv.conf` from being
+unmounted unexpectedly when `/etc/resolv.conf` on the host is regenerated.
 
 ```console
 (namespace)$ mkdir /tmp/a /tmp/b
@@ -172,7 +172,7 @@ nameserver 10.0.2.3
 
 # ROUTING PING PACKETS
 
-To route ping packets, you may need to set up **net.ipv4.ping_group_range** properly as the root.
+To route ping packets, you may need to set up `net.ipv4.ping_group_range` properly as the root.
 
 e.g.
 ```console
@@ -182,10 +182,10 @@ e.g.
 
 # FILTERING CONNECTIONS
 
-By default, ports listening on **INADDR_LOOPBACK** (**127.0.0.1**) on the host are accessible from the child namespace via the gateway (default: **10.0.2.2**).
-**--disable-host-loopback** can be used to prohibit connecting to **INADDR_LOOPBACK** on the host.
+By default, ports listening on `INADDR_LOOPBACK` (`127.0.0.1`) on the host are accessible from the child namespace via the gateway (default: `10.0.2.2`).
+`--disable-host-loopback` can be used to prohibit connecting to `INADDR_LOOPBACK` on the host.
 
-However, a host loopback address might be still accessible via the built-in DNS (default: **10.0.2.3**) if `/etc/resolv.conf` on the host refers to a loopback address.
+However, a host loopback address might be still accessible via the built-in DNS (default: `10.0.2.3`) if `/etc/resolv.conf` on the host refers to a loopback address.
 You may want to set up iptables for limiting access to the built-in DNS in such a case.
 
 ```console
@@ -202,7 +202,7 @@ slirp4netns can provide QMP-like API server over an UNIX socket file:
 (host)$ slirp4netns --api-socket /tmp/slirp4netns.sock ...
 ```
 
-**add_hostfwd**: Expose a port (IPv4 only)
+`add_hostfwd`: Expose a port (IPv4 only)
 
 ```console
 (namespace)$ json='{"execute": "add_hostfwd", "arguments": {"proto": "tcp", "host_addr": "0.0.0.0", "host_port": 8080, "guest_addr": "10.0.2.100", "guest_port": 80}}'
@@ -210,11 +210,11 @@ slirp4netns can provide QMP-like API server over an UNIX socket file:
 {"return": {"id": 42}}
 ```
 
-If **host_addr** is not specified, then it defaults to "0.0.0.0".
+If `host_addr` is not specified, then it defaults to "0.0.0.0".
 
-If **guest_addr** is not specified, then it will be set to the default address that corresponds to **--configure**.
+If `guest_addr` is not specified, then it will be set to the default address that corresponds to `--configure`.
 
-**list_hostfwd**: List exposed ports
+`list_hostfwd`: List exposed ports
 
 ```console
 (namespace)$ json='{"execute": "list_hostfwd"}'
@@ -222,7 +222,7 @@ If **guest_addr** is not specified, then it will be set to the default address t
 {"return": {"entries": [{"id": 42, "proto": "tcp", "host_addr": "0.0.0.0", "host_port": 8080, "guest_addr": "10.0.2.100", "guest_port": 80}]}}
 ```
 
-**remove_hostfwd**: Remove an exposed port
+`remove_hostfwd`: Remove an exposed port
 
 ```console
 (namespace)$ json='{"execute": "remove_hostfwd", "arguments": {"id": 42}}'
@@ -232,11 +232,11 @@ If **guest_addr** is not specified, then it will be set to the default address t
 
 Remarks:
 
-* Client needs to **shutdown(2)** the socket with **SHUT_WR** after sending every request.
+* Client needs to `shutdown(2)` the socket with `SHUT_WR` after sending every request.
   i.e. No support for keep-alive and timeout.
 * slirp4netns "stops the world" during processing API requests.
 * A request must be less than 4096 bytes.
-* JSON responses may contain **error** instead of **return**.
+* JSON responses may contain `error` instead of `return`.
 
 # DEFINED NAMESPACE PATHS 
 A user can define a network namespace path as opposed to the default process ID:
@@ -244,9 +244,9 @@ A user can define a network namespace path as opposed to the default process ID:
 ```console
 (host)$ slirp4netns --netns-type=path ... /path/to/netns tap0
 ```
-Currently, the **netns-type=TYPE** argument supports **path** or **pid** args with the default being **pid**.
+Currently, the `netns-type=TYPE` argument supports `path` or `pid` args with the default being `pid`.
 
-Additionally, a **--userns-path=PATH** argument can be included to override any user namespace path defaults
+Additionally, a `--userns-path=PATH` argument can be included to override any user namespace path defaults
 ```console
 (host)$ slirp4netns --netns-type=path --userns-path=/path/to/userns /path/to/netns tap0
 ```
@@ -289,7 +289,7 @@ The easiest way to allow inter-namespace communication is to nest network namesp
 
 However, this method does not work when you want to allow communication across multiple slirp4netns instances.
 To allow communication across multiple slirp4netns instances, you need to combine another network stack such as
-**vde_plug(1)** with slirp4netns.
+`vde_plug(1)` with slirp4netns.
 
 ```console
 (host)$ vde_plug --daemon switch:///tmp/switch null://
@@ -308,14 +308,14 @@ To allow communication across multiple slirp4netns instances, you need to combin
 # INTER-HOST COMMUNICATION
 
 VXLAN is known to work.
-See Usernetes project for the example of multi-node rootless Kubernetes cluster with VXLAN: **https://github.com/rootless-containers/usernetes**
+See Usernetes project for the example of multi-node rootless Kubernetes cluster with VXLAN: `https://github.com/rootless-containers/usernetes`
 
 # BUGS
 
-Kernel 4.20 bumped up the default value of **/proc/sys/net/ipv4/tcp_rmem** from 87380 to 131072.
-This is known to slow down slirp4netns port forwarding: **https://github.com/rootless-containers/slirp4netns/issues/128**.
+Kernel 4.20 bumped up the default value of `/proc/sys/net/ipv4/tcp_rmem` from 87380 to 131072.
+This is known to slow down slirp4netns port forwarding: `https://github.com/rootless-containers/slirp4netns/issues/128`.
 
-As a workaround, you can adjust the value of **/proc/sys/net/ipv4/tcp_rmem** inside the namespace.
+As a workaround, you can adjust the value of `/proc/sys/net/ipv4/tcp_rmem` inside the namespace.
 No real root privilege is needed to modify the file since kernel 4.15.
 
 ```console
@@ -325,8 +325,8 @@ No real root privilege is needed to modify the file since kernel 4.15.
 
 # SEE ALSO
 
-**network_namespaces**(7), **user_namespaces**(7), **veth**(4)
+`network_namespaces(7)`, `user_namespaces(7)`, `veth(4)`
 
 # AVAILABILITY
 
-The slirp4netns command is available from **https://github.com/rootless-containers/slirp4netns** under GNU GENERAL PUBLIC LICENSE Version 2 (or later).
+The slirp4netns command is available from `https://github.com/rootless-containers/slirp4netns` under GNU GENERAL PUBLIC LICENSE Version 2 (or later).

--- a/slirp4netns.1.md
+++ b/slirp4netns.1.md
@@ -1,4 +1,4 @@
-SLIRP4NETNS 1 "March 2020" "Rootless Containers" "User Commands"
+SLIRP4NETNS 1 "July 2020" "Rootless Containers" "User Commands"
 ==================================================
 
 # NAME
@@ -99,22 +99,35 @@ show version and exit
 
 # EXAMPLE
 
-Terminal 1: Create user/network/mount namespaces
+**Terminal 1**: Create user/network/mount namespaces
+
 ```console
-$ unshare --user --map-root-user --net --mount
-unshared$ echo $$ > /tmp/pid
+(host)$ unshare --user --map-root-user --net --mount
+(namespace)$ echo $$ > /tmp/pid
 ```
 
-Terminal 2: Start slirp4netns
+In this documentation, we use `(host)$` as the prompt of the host shell, `(namespace)$` as the prompt of the shell running in the namespaces.
+
+If `unshare` fails, try the following commands (known to be needed on Debian, Arch, and old CentOS 7.X):
+
 ```console
-$ slirp4netns --configure --mtu=65520 $(cat /tmp/pid) tap0
+(host)$ sudo sh -c 'echo "user.max_user_namespaces=28633" >> /etc/sysctl.d/userns.conf'
+(host)$ [ -f /proc/sys/kernel/unprivileged_serns_clone ] && sudo sh -c 'echo "kernel.unprivileged_userns_clone=1" >> /etc/sysctl.d/userns.conf'
+(host)$ sudo sysctl --system
+```
+
+**Terminal 2**: Start slirp4netns
+
+```console
+(host)$ slirp4netns --configure --mtu=65520 $(cat /tmp/pid) tap0
 starting slirp, MTU=65520
 ...
 ```
 
-Terminal 1: Make sure **tap0** is configured and connected to the Internet
+**Terminal 1**: Make sure **tap0** is configured and connected to the Internet
+
 ```console
-unshared$ ip a
+(namespace)$ ip a
 1: lo: <LOOPBACK> mtu 65536 qdisc noop state DOWN group default qlen 1000
     link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
 3: tap0: <BROADCAST,UP,LOWER_UP> mtu 65520 qdisc fq_codel state UNKNOWN group default qlen 1000
@@ -123,15 +136,14 @@ unshared$ ip a
        valid_lft forever preferred_lft forever
     inet6 fe80::c028:cff:fe0e:2906/64 scope link 
        valid_lft forever preferred_lft forever
-unshared$ echo "nameserver 10.0.2.3" > /tmp/resolv.conf
-unshared$ mount --bind /tmp/resolv.conf /etc/resolv.conf
-unshared$ curl https://example.com
+(namespace)$ echo "nameserver 10.0.2.3" > /tmp/resolv.conf
+(namespace)$ mount --bind /tmp/resolv.conf /etc/resolv.conf
+(namespace)$ curl https://example.com
 ```
 
 Bind-mounting **/etc/resolv.conf** is only needed when **/etc/resolv.conf** on
-the host refers to loopback addresses (**127.0.0.X**, typically because of
-**dnsmasq**(8) or **systemd-resolved.service**(8)) that cannot be accessed from
-the namespace.
+the host refers to loopback addresses (**127.0.0.X**, typically **dnsmasq**(8)
+or **systemd-resolved.service**(8)) that cannot be accessed from the namespace.
 
 If your **/etc/resolv.conf** on the host is managed by **networkmanager**(8)
 or **systemd-resolved.service**(8), you might need to mount a new filesystem on
@@ -139,26 +151,33 @@ or **systemd-resolved.service**(8), you might need to mount a new filesystem on
 unmounted unexpectedly when **/etc/resolv.conf** on the host is regenerated.
 
 ```console
-unshared$ mkdir /tmp/a /tmp/b
-unshared$ mount --rbind /etc /tmp/a
-unshared$ mount --rbind /tmp/b /etc
-unshared$ mkdir /etc/.ro
-unshared$ mount --move /tmp/a /etc/.ro
-unshared$ cd /etc
-unshared$ for f in .ro/*; do ln -s $f $(basename $f); done
-unshared$ rm resolv.conf
-unshared$ echo "nameserver 10.0.2.3" > /tmp/resolv.conf
-unshared$ curl https://example.com
+(namespace)$ mkdir /tmp/a /tmp/b
+(namespace)$ mount --rbind /etc /tmp/a
+(namespace)$ mount --rbind /tmp/b /etc
+(namespace)$ mkdir /etc/.ro
+(namespace)$ mount --move /tmp/a /etc/.ro
+(namespace)$ cd /etc
+(namespace)$ for f in .ro/*; do ln -s $f $(basename $f); done
+(namespace)$ rm resolv.conf
+(namespace)$ echo "nameserver 10.0.2.3" > resolv.conf
+(namespace)$ curl https://example.com
+```
+
+These steps can be simplified with `rootlesskit --copy-up=/etc` if `rootlesskit` is installed:
+```console
+(host)$ rootlesskit --net=slirp4netns --copy-up=/etc bash
+(namespace)$ cat /etc/resolv.conf
+nameserver 10.0.2.3
 ```
 
 # ROUTING PING PACKETS
 
-To route ping packets, you need to set up **net.ipv4.ping_group_range** properly
-as the root.
+To route ping packets, you may need to set up **net.ipv4.ping_group_range** properly as the root.
 
 e.g.
 ```console
-$ sudo sh -c "echo 0   2147483647  > /proc/sys/net/ipv4/ping_group_range"
+(host)$ sudo sh -c 'echo "net.ipv4.ping_group_range=0   2147483647" > /etc/sysctl.d/ping_group_range.conf'
+(host)$ sudo sysctl --system
 ```
 
 # FILTERING CONNECTIONS
@@ -170,8 +189,9 @@ However, a host loopback address might be still accessible via the built-in DNS 
 You may want to set up iptables for limiting access to the built-in DNS in such a case.
 
 ```console
-unshared$ iptables -A OUTPUT -d 10.0.2.3 -p udp --dport 53 -j ACCEPT
-unshared$ iptables -A OUTPUT -d 10.0.2.3 -j DROP
+(host)$ nsenter -t $(cat /tmp/pid) -U -n
+(namespace)$ iptables -A OUTPUT -d 10.0.2.3 -p udp --dport 53 -j ACCEPT
+(namespace)$ iptables -A OUTPUT -d 10.0.2.3 -j DROP
 ```
 
 # API SOCKET
@@ -179,35 +199,35 @@ unshared$ iptables -A OUTPUT -d 10.0.2.3 -j DROP
 slirp4netns can provide QMP-like API server over an UNIX socket file:
 
 ```console
-$ slirp4netns --api-socket /tmp/slirp4netns.sock ...
+(host)$ slirp4netns --api-socket /tmp/slirp4netns.sock ...
 ```
 
 **add_hostfwd**: Expose a port (IPv4 only)
 
 ```console
-$ json='{"execute": "add_hostfwd", "arguments": {"proto": "tcp", "host_addr": "0.0.0.0", "host_port": 8080, "guest_addr": "10.0.2.100", "guest_port": 80}}'
-$ echo -n $json | nc -U /tmp/slirp4netns.sock
-{ "return": {"id": 42}}
+(namespace)$ json='{"execute": "add_hostfwd", "arguments": {"proto": "tcp", "host_addr": "0.0.0.0", "host_port": 8080, "guest_addr": "10.0.2.100", "guest_port": 80}}'
+(namespace)$ echo -n $json | nc -U /tmp/slirp4netns.sock
+{"return": {"id": 42}}
 ```
 
 If **host_addr** is not specified, then it defaults to "0.0.0.0".
 
-If **guest_addr** is not specified, then it will be set to the default address that corresponds to --configure.
+If **guest_addr** is not specified, then it will be set to the default address that corresponds to **--configure**.
 
 **list_hostfwd**: List exposed ports
 
 ```console
-$ json='{"execute": "list_hostfwd"}'
-$ echo -n $json | nc -U /tmp/slirp4netns.sock
-{ "return": {"entries": [{"id": 42, "proto": "tcp", "host_addr": "0.0.0.0", "host_port": 8080, "guest_addr": "10.0.2.100", "guest_port": 80}]}}
+(namespace)$ json='{"execute": "list_hostfwd"}'
+(namespace)$ echo -n $json | nc -U /tmp/slirp4netns.sock
+{"return": {"entries": [{"id": 42, "proto": "tcp", "host_addr": "0.0.0.0", "host_port": 8080, "guest_addr": "10.0.2.100", "guest_port": 80}]}}
 ```
 
 **remove_hostfwd**: Remove an exposed port
 
 ```console
-$ json='{"execute": "remove_hostfwd", "arguments": {"id": 42}}'
-$ echo -n $json | nc -U /tmp/slirp4netns.sock
-{ "return": {}}
+(namespace)$ json='{"execute": "remove_hostfwd", "arguments": {"id": 42}}'
+(namespace)$ echo -n $json | nc -U /tmp/slirp4netns.sock
+{"return": {}}
 ```
 
 Remarks:
@@ -222,27 +242,73 @@ Remarks:
 A user can define a network namespace path as opposed to the default process ID:
 
 ```console
-$ slirp4netns --netns-type=path ... /path/to/netns tap0
+(host)$ slirp4netns --netns-type=path ... /path/to/netns tap0
 ```
 Currently, the **netns-type=TYPE** argument supports **path** or **pid** args with the default being **pid**.
 
 Additionally, a **--userns-path=PATH** argument can be included to override any user namespace path defaults
 ```console
-$ slirp4netns --netns-type=path --userns-path=/path/to/userns /path/to/netns tap0
+(host)$ slirp4netns --netns-type=path --userns-path=/path/to/userns /path/to/netns tap0
 ```
 
 # OUTBOUND ADDRESSES 
 A user can defined preferred outbound ipv4 and ipv6 address in multi IP scenarios. 
 
 ```console
-$ slirp4netns --outbound-addr=10.2.2.10 --outbound-addr6=fe80::10 ...
+(host)$ slirp4netns --outbound-addr=10.2.2.10 --outbound-addr6=fe80::10 ...
 ```
 
 Optionally you can use interface names instead of ip addresses. 
 
 ```console
-$ slirp4netns --outbound-addr=eth0 --outbound-addr6=eth0 ...
+(host)$ slirp4netns --outbound-addr=eth0 --outbound-addr6=eth0 ...
 ```
+
+# INTER-NAMESPACE COMMUNICATION
+
+The easiest way to allow inter-namespace communication is to nest network namespaces inside the slirp4netns's network namespace.
+
+```console
+(host)$ nsenter -t $(cat /tmp/pid) -U -n -m
+(namespace)$ mount -t tmpfs none /run
+(namespace)$ ip netns add foo
+(namespace)$ ip netns add bar
+(namespace)$ ip link add veth-foo type veth peer name veth-bar
+(namespace)$ ip link set veth-foo netns foo
+(namespace)$ ip link set veth-bar netns bar
+(namespace)$ ip netns exec foo ip link set veth-foo name eth0
+(namespace)$ ip netns exec bar ip link set veth-bar name eth0
+(namespace)$ ip netns exec foo ip link set lo up
+(namespace)$ ip netns exec bar ip link set lo up
+(namespace)$ ip netns exec foo ip link set eth0 up
+(namespace)$ ip netns exec bar ip link set eth0 up
+(namespace)$ ip netns exec foo ip addr add 192.168.42.100/24 dev eth0
+(namespace)$ ip netns exec bar ip addr add 192.168.42.101/24 dev eth0
+(namespace)$ ip netns exec bar ping 192.168.42.100
+```
+
+However, this method does not work when you want to allow communication across multiple slirp4netns instances.
+To allow communication across multiple slirp4netns instances, you need to combine another network stack such as
+**vde_plug(1)** with slirp4netns.
+
+```console
+(host)$ vde_plug --daemon switch:///tmp/switch null://
+(host)$ nsenter -t $(cat /tmp/pid-instance0) -U -n
+(namespace-instance0)$ vde_plug --daemon vde:///tmp/switch tap://vde
+(namespace-instance0)$ ip link set vde up
+(namespace-instance0)$ ip addr add 192.168.42.100/24 dev vde
+(namespace-instance0)$ exit
+(host)$ nsenter -t $(cat /tmp/pid-instance1) -U -n
+(namespace-instance1)$ vde_plug --daemon vde:///tmp/switch tap://vde
+(namespace-instance1)$ ip link set vde up
+(namespace-instance1)$ ip addr add 192.168.42.101/24 dev vde
+(namespace-instance1)$ ping 192.168.42.100
+```
+
+# INTER-HOST COMMUNICATION
+
+VXLAN is known to work.
+See Usernetes project for the example of multi-node rootless Kubernetes cluster with VXLAN: **https://github.com/rootless-containers/usernetes**
 
 # BUGS
 
@@ -253,7 +319,8 @@ As a workaround, you can adjust the value of **/proc/sys/net/ipv4/tcp_rmem** ins
 No real root privilege is needed to modify the file since kernel 4.15.
 
 ```console
-unshared$ c=$(cat /proc/sys/net/ipv4/tcp_rmem); echo $c | sed -e s/131072/87380/g > /proc/sys/net/ipv4/tcp_rmem
+(host)$ nsenter -t $(cat /tmp/pid) -U -n -m
+(namespace)$ c=$(cat /proc/sys/net/ipv4/tcp_rmem); echo $c | sed -e s/131072/87380/g > /proc/sys/net/ipv4/tcp_rmem
 ```
 
 # SEE ALSO


### PR DESCRIPTION
See "Inter-namespace communication" section of the man page for how to allow communication across multiple slirp4netns instances.

Fix #172

