### PR TITLE
v1.1.3

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        libslirp_commit: [master, v4.3.0, v4.2.0, v4.1.0]
+        libslirp_commit: [master, v4.3.1, v4.2.0, v4.1.0]
     steps:
     - uses: actions/checkout@v2
     - run: docker build -t slirp4netns-tests --build-arg LIBSLIRP_COMMIT -f Dockerfile.tests .

--- a/Dockerfile.artifact
+++ b/Dockerfile.artifact
@@ -1,4 +1,4 @@
-ARG LIBSLIRP_COMMIT=v4.3.0
+ARG LIBSLIRP_COMMIT=v4.3.1
 
 FROM --platform=$TARGETPLATFORM debian:10 AS build
 RUN apt update && apt install -y automake autotools-dev make gcc libglib2.0-dev libcap-dev libseccomp-dev git ninja-build python3-pip

--- a/Dockerfile.buildtests
+++ b/Dockerfile.buildtests
@@ -1,4 +1,4 @@
-ARG LIBSLIRP_COMMIT=v4.3.0
+ARG LIBSLIRP_COMMIT=v4.3.1
 
 # Alpine
 FROM alpine:3 AS buildtest-alpine3-static

--- a/Dockerfile.tests
+++ b/Dockerfile.tests
@@ -1,4 +1,4 @@
-ARG LIBSLIRP_COMMIT=v4.3.0
+ARG LIBSLIRP_COMMIT=v4.3.1
 
 FROM ubuntu:18.04 AS build
 RUN apt update && apt install -y automake autotools-dev make gcc libglib2.0-dev libcap-dev libseccomp-dev git ninja-build python3-pip

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.69])
-AC_INIT([slirp4netns], [1.1.3], [https://github.com/rootless-containers/slirp4netns/issues])
+AC_INIT([slirp4netns], [1.1.3+dev], [https://github.com/rootless-containers/slirp4netns/issues])
 AC_CONFIG_SRCDIR([main.c])
 AC_CONFIG_HEADERS([config.h])
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.69])
-AC_INIT([slirp4netns], [1.1.2+dev], [https://github.com/rootless-containers/slirp4netns/issues])
+AC_INIT([slirp4netns], [1.1.3], [https://github.com/rootless-containers/slirp4netns/issues])
 AC_CONFIG_SRCDIR([main.c])
 AC_CONFIG_HEADERS([config.h])
 


### PR DESCRIPTION
Notable changes since v1.1.2:
* No change on the source code
* Updated docs (#215)
* Updated binaries to be linked with libslirp v4.3.1.

libslirp v4.3.1 contains the fix for [**CVE-2020-10756**](https://nvd.nist.gov/vuln/detail/CVE-2020-10756)): https://gitlab.freedesktop.org/slirp/libslirp/-/blob/v4.3.1/CHANGELOG.md

> **NOTE** 
> Nobody is likely to be actually affected by this CVE. See our security advisory: https://github.com/rootless-containers/slirp4netns/security/advisories/GHSA-96c5-v27g-58vf
>
> Also, you do NOT need to install this release if the slirp4netns binary on your system is dynamically linked with libslirp (>= v4.3.1).



