### PR TITLE
Avoid SCMP_ACT_KILL_PROCESS in seccompfilter

### DIFF
--- a/seccompfilter.c
+++ b/seccompfilter.c
@@ -24,11 +24,10 @@ int enable_seccomp()
         }
     }
     printf("seccomp: The following syscalls will be blocked by seccomp:");
-#ifdef SCMP_ACT_KILL_PROCESS
-#define BLOCK_ACTION SCMP_ACT_KILL_PROCESS
-#else
+/* Setting BLOCK_ACTION to SCMP_ACT_KILL_PROCESS results in issues reported at:
+ *  - https://github.com/rootless-containers/slirp4netns/issues/221
+ *  - https://github.com/containers/podman/issues/6967 */
 #define BLOCK_ACTION SCMP_ACT_KILL
-#endif
 #define BLOCK(x)                                                  \
     {                                                             \
         rc = seccomp_rule_add(ctx, BLOCK_ACTION, SCMP_SYS(x), 0); \


### PR DESCRIPTION
The issues with error message
```
Error: /usr/bin/slirp4netns failed: "sent tapfd=7 for tap0\nWARNING: Support for seccomp is experimental\nreceived tapfd=7\nenable_seccomp failed\ndo_slirp is exiting\ndo_slirp failed\nparent failed\n
```
reported at
- https://github.com/rootless-containers/slirp4netns/issues/221 and
- https://github.com/containers/podman/issues/6967

are not observed with the official statically linked binaries because it is built on Debian 10 with libseccomp 4.3.3 which does not support `SCMP_ACT_KILL_PROCESS`.
Builds that use libseccomp 4.4 at compile time have `SCMP_ACT_KILL_PROCESS` defined and as such behave differently due to the `#ifdef` that is being removed with this PR.

Unfortunately, I can't tell what the underlying issue is because I have no experience with seccomp.
I only noticed this behavior while packaging slirp4netns and libslirp at https://github.com/conda-forge/staged-recipes/pull/13079.