### PR TITLE
seccompfilter: Use SCMP_ACT_KILL_PROCESS only on compatible kernels

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -17,6 +17,39 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - run: DOCKER_BUILDKIT=1 docker build -f Dockerfile.buildtests .
+  test-centos:
+    runs-on: macos-latest
+    env:
+      LIBSECCOMP_COMMIT: v2.3.3
+      LIBSLIRP_COMMIT: v4.1.0
+      BENCHMARK_IPERF3_DURATION: 3
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup CentOS 7 VM
+      run: |
+        vagrant up --provision --no-tty
+        cat > ./run-vagrant-tests <<'EOF'
+        exec vagrant ssh --no-tty -c "
+          export LIBSECCOMP_COMMIT=\"${LIBSECCOMP_COMMIT}\"
+          export LIBSLIRP_COMMIT=\"${LIBSLIRP_COMMIT}\"
+          export BENCHMARK_IPERF3_DURATION=\"${BENCHMARK_IPERF3_DURATION}\"
+          /src/build-and-test
+        "
+        EOF
+    - name: Build and test with Debian 10's version of libseccomp
+      run: sh ./run-vagrant-tests
+    - name: Build and test with Ubuntu 20.04's versions of libseccomp/libslirp
+      run: sh ./run-vagrant-tests
+      env:
+        LIBSECCOMP_COMMIT: v2.4.3
+        LIBSLIRP_COMMIT: v4.1.0
+    - name: Build and test with recent versions of libseccomp/libslirp
+      run: sh ./run-vagrant-tests
+      env:
+        LIBSECCOMP_COMMIT: v2.5.0
+        LIBSLIRP_COMMIT: v4.2.0
+        # Fails with --disable-dns from libslirp >=4.3.0
+        # (no timeout in test-slirp4netns-disable-dns.sh).
   artifact:
     runs-on: ubuntu-latest
     steps:

--- a/Makefile.am
+++ b/Makefile.am
@@ -54,12 +54,12 @@ indent:
 	$(CLANGFORMAT) -i $(slirp4netns_SOURCES)
 
 benchmark:
-	benchmarks/benchmark-iperf3.sh
-	benchmarks/benchmark-iperf3-reverse.sh
+	"$(abs_srcdir)/benchmarks/benchmark-iperf3.sh"
+	"$(abs_srcdir)/benchmarks/benchmark-iperf3-reverse.sh"
 
 ci:
 	$(MAKE) indent
-	git diff --exit-code
+	git -C "$(abs_srcdir)" diff --exit-code
 # TODO: make sure ./vendor is synced with ./vendor.sh
 	$(MAKE) lint
 	$(MAKE) -j $(shell nproc) distcheck || ( find . -name test-suite.log | xargs cat; exit 1 )

--- a/Makefile.am
+++ b/Makefile.am
@@ -5,7 +5,7 @@ AM_CFLAGS = @GLIB_CFLAGS@ @SLIRP_CFLAGS@ @LIBCAP_CFLAGS@ @LIBSECCOMP_CFLAGS@
 noinst_LIBRARIES = libparson.a
 
 AM_TESTS_ENVIRONMENT = PATH="$(abs_top_builddir):$(PATH)"
-TESTS = tests/test-slirp4netns.sh tests/test-slirp4netns-configure.sh tests/test-slirp4netns-exit-fd.sh tests/test-slirp4netns-ready-fd.sh tests/test-slirp4netns-api-socket.sh tests/test-slirp4netns-disable-host-loopback.sh tests/test-slirp4netns-cidr.sh tests/test-slirp4netns-outbound-addr.sh tests/test-slirp4netns-disable-dns.sh
+TESTS = tests/test-slirp4netns.sh tests/test-slirp4netns-configure.sh tests/test-slirp4netns-exit-fd.sh tests/test-slirp4netns-ready-fd.sh tests/test-slirp4netns-api-socket.sh tests/test-slirp4netns-disable-host-loopback.sh tests/test-slirp4netns-cidr.sh tests/test-slirp4netns-outbound-addr.sh tests/test-slirp4netns-disable-dns.sh tests/test-slirp4netns-seccomp.sh
 
 EXTRA_DIST = \
 	slirp4netns.1.md \

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,82 @@
+Vagrant.configure("2") do |config|
+  require 'etc'
+  config.vm.provider "virtualbox" do |vbox|
+    vbox.cpus = [1, Etc.nprocessors].max
+  end
+  config.vm.box = "centos/7"
+  config.vm.synced_folder ".", "/vagrant", disabled: true
+  config.vm.synced_folder ".", "/src/slirp4netns", type: "rsync"
+  config.vm.provision "shell",
+    inline: <<~'SHELL'
+      set -xeu
+      sysctl user.max_user_namespaces=65536
+
+      yum install -y \
+        epel-release \
+        https://repo.ius.io/ius-release-el7.rpm
+
+      yum install -y \
+        autoconf automake make gcc gperf libtool \
+        git-core meson ninja-build \
+        glib2-devel libcap-devel \
+        git-core libtool iproute iputils iperf3 nmap jq
+
+      cd /src
+      chown vagrant .
+
+      su vagrant -c '
+        set -xeu
+
+        git clone --depth=1 --no-checkout https://github.com/seccomp/libseccomp
+        git -C ./libseccomp fetch --tags --depth=1
+
+        git clone --depth=1 --no-checkout https://gitlab.freedesktop.org/slirp/libslirp.git
+        git -C ./libslirp fetch --tags --depth=1
+
+        touch ./build-and-test
+        chmod a+x ./build-and-test
+      '
+
+      cat > ./build-and-test <<'EOS'
+      #! /bin/sh
+      set -xeu
+      src_dir='/src'
+
+      prefix="${PREFIX:-${HOME}/prefix}"
+      build_root="${BUILD_ROOT:-${prefix}/build}"
+      rm -rf "${prefix}" "${build_root}"
+      mkdir -p "${build_root}"
+
+      export CFLAGS="-I${prefix}"
+      export LDFLAGS="-L${prefix} -Wl,-rpath,${prefix}/lib"
+      export PKG_CONFIG_PATH="${prefix}/lib/pkgconfig${PKG_CONFIG_PATH:+:${PKG_CONFIG_PATH}}"
+
+      git -C "${src_dir}/libseccomp" fetch --depth=1 origin "${LIBSECCOMP_COMMIT:-v2.4.3}"
+      git -C "${src_dir}/libseccomp" checkout FETCH_HEAD
+      ( cd "${src_dir}/libseccomp" && ./autogen.sh )
+      mkdir "${build_root}/libseccomp"
+      pushd "${build_root}/libseccomp"
+      "${src_dir}/libseccomp/configure" --prefix="${prefix}"
+      make -j "$( nproc )" CFLAGS+="-I$( pwd )/include"
+      make install
+      popd
+
+      git -C "${src_dir}/libslirp" fetch --depth=1 origin "${LIBSLIRP_COMMIT:-v4.1.0}"
+      git -C "${src_dir}/libslirp" checkout FETCH_HEAD
+      mkdir "${build_root}/libslirp"
+      pushd "${build_root}/libslirp"
+      meson setup --prefix="${prefix}" --libdir=lib . "${src_dir}/libslirp"
+      ninja -C . install
+      popd
+
+      ( cd "${src_dir}/slirp4netns" && ./autogen.sh )
+      mkdir "${build_root}/slirp4netns"
+      pushd "${build_root}/slirp4netns"
+      "${src_dir}/slirp4netns/configure" --prefix="${prefix}"
+      make -j "$( nproc )"
+
+      make ci 'CLANGTIDY=echo skipping:' 'CLANGFORMAT=echo skipping:'
+      popd
+      EOS
+    SHELL
+end

--- a/benchmarks/benchmark-iperf3-reverse.sh
+++ b/benchmarks/benchmark-iperf3-reverse.sh
@@ -30,4 +30,4 @@ function cleanup {
 }
 trap cleanup EXIT
 
-iperf3 -c 127.0.0.1 -p 15201 -t 60
+iperf3 -c 127.0.0.1 -p 15201 -t "${BENCHMARK_IPERF3_DURATION:-60}"

--- a/benchmarks/benchmark-iperf3.sh
+++ b/benchmarks/benchmark-iperf3.sh
@@ -23,4 +23,4 @@ function cleanup {
 }
 trap cleanup EXIT
 
-nsenter --preserve-credentials -U -n --target=$child iperf3 -c 10.0.2.2 -t 60
+nsenter --preserve-credentials -U -n --target=$child iperf3 -c 10.0.2.2 -t "${BENCHMARK_IPERF3_DURATION:-60}"

--- a/configure.ac
+++ b/configure.ac
@@ -6,7 +6,8 @@ AC_CONFIG_HEADERS([config.h])
 AC_PROG_CC
 AC_PROG_RANLIB
 
-AM_INIT_AUTOMAKE([1.9 foreign subdir-objects])
+AM_INIT_AUTOMAKE([1.11.2 foreign subdir-objects])
+AM_PROG_AR
 
 AC_CHECK_HEADERS([arpa/inet.h fcntl.h netdb.h netinet/in.h stddef.h stdint.h stdlib.h string.h sys/ioctl.h sys/mount.h sys/socket.h sys/timeb.h unistd.h getopt.h])
 

--- a/tests/slirp4netns-no-unmount.sh
+++ b/tests/slirp4netns-no-unmount.sh
@@ -11,7 +11,7 @@ mkdir /run/foo
 mount -t tmpfs tmpfs /run/foo
 mount --make-rshared /run
 
-unshare -n sleep infinity &
+unshare -r -n sleep infinity &
 child=$!
 
 wait_for_network_namespace $child

--- a/tests/slirp4netns-no-unmount.sh
+++ b/tests/slirp4netns-no-unmount.sh
@@ -11,7 +11,7 @@ mkdir /run/foo
 mount -t tmpfs tmpfs /run/foo
 mount --make-rshared /run
 
-unshare -r -n sleep infinity &
+unshare -n sleep infinity &
 child=$!
 
 wait_for_network_namespace $child

--- a/tests/test-slirp4netns-cidr.sh
+++ b/tests/test-slirp4netns-cidr.sh
@@ -43,5 +43,5 @@ function cleanup {
 }
 trap cleanup EXIT
 
-ip=$(nsenter --preserve-credentials -U -n --target=$child ip -json a show dev tun11 | jq -r .[1].addr_info[0].local)
-[[ $ip = 10.0.135.228 ]]
+result="$(nsenter --preserve-credentials -U -n --target=$child ip a show dev tun11)"
+echo "$result" | grep -om1 '^\s*inet .*/' | grep -qF 10.0.135.228

--- a/tests/test-slirp4netns-seccomp.sh
+++ b/tests/test-slirp4netns-seccomp.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -xeuo pipefail
+
+. $(dirname $0)/common.sh
+
+unshare -r -n sleep infinity &
+child=$!
+
+wait_for_network_namespace $child
+
+slirp4netns -c --enable-seccomp --userns-path=/proc/$child/ns/user $child tun11 &
+slirp_pid=$!
+
+wait_for_network_device $child tun11
+
+function cleanup {
+    kill -9 $child $slirp_pid
+}
+trap cleanup EXIT
+
+nsenter --preserve-credentials -U -n --target=$child ip -a netconf | grep tun11
+
+nsenter --preserve-credentials -U -n --target=$child ip addr show tun11 | grep inet


### PR DESCRIPTION
Supersedes gh-232.

> seccompfilter: Conditional SCMP_ACT_KILL_PROCESS
>
> As before, this only uses SCMP_ACT_KILL_PROCESS for libseccomp versions
> which define it.
> Additionally, it is only used if at run time the kernel reports it as a
> supported action. For this SECCOMP_GET_ACTION_AVAIL must be available
> (supported from Linux 4.14 onward and backported to CentOS 7's kernel)
> and SECCOMP_RET_KILL_PROCESS (Linux 4.14+, but not in CentOS 7).

This also adds/changes the following:
- Add a CentOS 7 VM/Vagrant-based test run for compatibility (regression) testing on older kernels.
- Add a test case for `--enable-seccomp`.
- Small adjustments to allow CI tests to run on CentOS 7, run out of tree, complete faster.