### PR TITLE
tests: Avoid timeout in slirp4netns-no-unmount.sh

### DIFF
--- a/tests/slirp4netns-no-unmount.sh
+++ b/tests/slirp4netns-no-unmount.sh
@@ -11,7 +11,7 @@ mkdir /run/foo
 mount -t tmpfs tmpfs /run/foo
 mount --make-rshared /run
 
-unshare -n sleep infinity &
+unshare -r -n sleep infinity &
 child=$!
 
 wait_for_network_namespace $child


### PR DESCRIPTION
Cherry-picked https://github.com/rootless-containers/slirp4netns/commit/189e1edbc6bf05f7df2d38c2b74504540b7595cc .
Discussion at https://github.com/rootless-containers/slirp4netns/pull/234#pullrequestreview-530783907 :

----
@mbargull:
> Without this the tests (also on Ubuntu) are prolonged by 40s due to the 2 x 40 x 0.5s waiting from `wait_for_network_namespace` and `wait_for_network_device`.

@AkihiroSuda 
> This seems to need investigation. I don't think we should need `-r` here.
> 
> cc @giuseppe

@giuseppe:
> the user should already have enough privileges to run these tests, why does the new user namespace make a difference?

@mbargull
> I have no idea, unfortunately (not my area of expertise). I only noticed this while running the tests.
> I reverted the associated commit for now.
> @AkihiroSuda, @giuseppe can you open an issue to track this?
> (Asking you because you can give more context than unknowledgeable me.)