### PR TITLE
CI: Test with libslirp 4.3.1 on CentOS 7

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -47,9 +47,7 @@ jobs:
       run: sh ./run-vagrant-tests
       env:
         LIBSECCOMP_COMMIT: v2.5.0
-        LIBSLIRP_COMMIT: v4.2.0
-        # Fails with --disable-dns from libslirp >=4.3.0
-        # (no timeout in test-slirp4netns-disable-dns.sh).
+        LIBSLIRP_COMMIT: v4.3.1
   artifact:
     runs-on: ubuntu-20.04
     steps:


### PR DESCRIPTION
This is a followup to https://github.com/rootless-containers/slirp4netns/pull/234#discussion_r523735247 :

----
@mbargull in https://github.com/rootless-containers/slirp4netns/pull/234#discussion_r523735247 :
> I did not investigate this further, so can't tell if it's kernel or `ncat` version related, but with libslirp 4.3.1 the `--disable-dns` did not show the expected timeout.

@AkihiroSuda in https://github.com/rootless-containers/slirp4netns/pull/234#discussion_r523911136 :
> timeout of what?

@mbargull in https://github.com/rootless-containers/slirp4netns/pull/234#discussion_r523984433 :
> https://github.com/rootless-containers/slirp4netns/blob/v1.1.6/tests/test-slirp4netns-disable-dns.sh#L33-L35 does not get a timeout message to `grep` for (the `ncat` seems to succeed).

----
@AkihiroSuda, I don't know if you'd want to investigate this further. I'm just opening this here for demonstrative purposes.
Feel free to amend or close!