### PR TITLE
Vagrantfile: change VirtualBox itself's slirp CIDR + Test with libslirp 4.3.1 on CentOS 7

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -47,9 +47,7 @@ jobs:
       run: sh ./run-vagrant-tests
       env:
         LIBSECCOMP_COMMIT: v2.5.0
-        LIBSLIRP_COMMIT: v4.2.0
-        # Fails with --disable-dns from libslirp >=4.3.0
-        # (no timeout in test-slirp4netns-disable-dns.sh).
+        LIBSLIRP_COMMIT: v4.3.1
   artifact:
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - run: DOCKER_BUILDKIT=1 docker build -f Dockerfile.buildtests .
-  test-centos:
+  test-centos7:
     runs-on: macos-latest
     env:
       LIBSECCOMP_COMMIT: v2.3.3

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ a.out
 config.h
 config.status
 INSTALL
+/.vagrant
 
 ################################################################################
 # https://github.com/github/gitignore/blob/c24cdc2175d7514d504d7f060a5d69675c8a9b50/Autotools.gitignore

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,6 +2,8 @@ Vagrant.configure("2") do |config|
   require 'etc'
   config.vm.provider "virtualbox" do |vbox|
     vbox.cpus = [1, Etc.nprocessors].max
+# Change VirtualBox itself's slirp CIDR so that it doesn't conflict with slirp4netns
+    vbox.customize ["modifyvm", :id, "--natnet1", "10.0.200.0/24"]
   end
   config.vm.box = "centos/7"
   config.vm.synced_folder ".", "/vagrant", disabled: true


### PR DESCRIPTION
VirtualBox itself's slirp 10.0.2.0/24 was conflicting with slirp4netns CIDR

Contains #236 