### PR TITLE
Add the --macaddress option to specify the MAC address of the tap interface.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -5,7 +5,7 @@ AM_CFLAGS = @GLIB_CFLAGS@ @SLIRP_CFLAGS@ @LIBCAP_CFLAGS@ @LIBSECCOMP_CFLAGS@
 noinst_LIBRARIES = libparson.a
 
 AM_TESTS_ENVIRONMENT = PATH="$(abs_top_builddir):$(PATH)"
-TESTS = tests/test-slirp4netns.sh tests/test-slirp4netns-configure.sh tests/test-slirp4netns-exit-fd.sh tests/test-slirp4netns-ready-fd.sh tests/test-slirp4netns-api-socket.sh tests/test-slirp4netns-disable-host-loopback.sh tests/test-slirp4netns-cidr.sh tests/test-slirp4netns-outbound-addr.sh tests/test-slirp4netns-disable-dns.sh tests/test-slirp4netns-seccomp.sh
+TESTS = tests/test-slirp4netns.sh tests/test-slirp4netns-configure.sh tests/test-slirp4netns-exit-fd.sh tests/test-slirp4netns-ready-fd.sh tests/test-slirp4netns-api-socket.sh tests/test-slirp4netns-disable-host-loopback.sh tests/test-slirp4netns-cidr.sh tests/test-slirp4netns-outbound-addr.sh tests/test-slirp4netns-disable-dns.sh tests/test-slirp4netns-seccomp.sh tests/test-slirp4netns-macaddress.sh
 
 EXTRA_DIST = \
 	slirp4netns.1.md \

--- a/slirp4netns.1
+++ b/slirp4netns.1
@@ -124,6 +124,10 @@ specify outbound interface slirp should bind to (ipv6 traffic only)
 disable built\-in DNS (10.0.2.3 by default)
 
 .PP
+\fB\fC\-\-macaddress\fR (since v1.1.9)
+specify MAC address of the TAP interface (only valid with \-c)
+
+.PP
 \fB\fC\-h\fR, \fB\fC\-\-help\fR (since v0.2.0)
 show help and exit
 

--- a/slirp4netns.1.md
+++ b/slirp4netns.1.md
@@ -90,6 +90,9 @@ specify outbound interface slirp should bind to (ipv6 traffic only)
 `--disable-dns` (since v1.1.0)
 disable built-in DNS (10.0.2.3 by default)
 
+`--macaddress` (since v1.1.9)
+specify MAC address of the TAP interface (only valid with -c)
+
 `-h`, `--help` (since v0.2.0)
 show help and exit
 

--- a/slirp4netns.h
+++ b/slirp4netns.h
@@ -25,6 +25,8 @@ struct slirp4netns_config {
 #if SLIRP_CONFIG_VERSION_MAX >= 3
     bool disable_dns;
 #endif
+    struct sockaddr vmacaddress; // MAC address of interface
+    int vmacaddress_len; // MAC address byte length
 };
 int do_slirp(int tapfd, int readyfd, int exitfd, const char *api_socket,
              struct slirp4netns_config *cfg);

--- a/tests/test-slirp4netns-macaddress.sh
+++ b/tests/test-slirp4netns-macaddress.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -xeuo pipefail
+
+. $(dirname $0)/common.sh
+MACADDRESS="0e:d4:18:d9:38:fb"
+
+unshare -r -n sleep infinity &
+child=$!
+
+wait_for_network_namespace $child
+
+function cleanup {
+    kill -9 $child $slirp_pid
+}
+trap cleanup EXIT
+
+slirp4netns -c --macaddress $MACADDRESS $child tun11 &
+slirp_pid=$!
+
+wait_for_network_device $child tun11
+
+result=$(nsenter --preserve-credentials -U -n --target=$child ip addr show tun11 | grep -o "ether $MACADDRESS")
+
+if [ -z "$result" ]; then
+  printf "expecting %s MAC address on the interface but didn't get it" "$MACADDRESS"
+  exit 1
+fi
+
+cleanup


### PR DESCRIPTION
Signed-off-by: Brian Koehmstedt <bkoehm@gmail.com>