### PR TITLE
Support BESS protocol (for UML)

### DIFF
--- a/Dockerfile.artifact
+++ b/Dockerfile.artifact
@@ -5,7 +5,7 @@ FROM --platform=$TARGETPLATFORM debian:${DEBIAN_VERSION} AS build
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt update && apt install -y automake autotools-dev make gcc libglib2.0-dev libcap-dev libseccomp-dev git ninja-build python3-pip
 RUN pip3 install meson
-RUN git clone https://gitlab.freedesktop.org/slirp/libslirp.git /libslirp
+RUN git clone git://git.qemu.org/libslirp.git /libslirp
 WORKDIR /libslirp
 ARG LIBSLIRP_COMMIT
 RUN  git pull && git checkout ${LIBSLIRP_COMMIT} && meson setup --default-library=both build && ninja -C build install

--- a/Dockerfile.buildtests
+++ b/Dockerfile.buildtests
@@ -3,7 +3,7 @@ ARG LIBSLIRP_COMMIT=v4.6.1
 # Alpine
 FROM alpine:3 AS buildtest-alpine3-static
 RUN apk add --no-cache git build-base autoconf automake libtool linux-headers glib-dev glib-static libcap-static libcap-dev libseccomp-dev libseccomp-static git meson
-RUN git clone https://gitlab.freedesktop.org/slirp/libslirp.git /libslirp
+RUN git clone git://git.qemu.org/libslirp.git /libslirp
 WORKDIR /libslirp
 ARG LIBSLIRP_COMMIT
 RUN  git pull && git checkout ${LIBSLIRP_COMMIT} && meson setup --default-library=both build && ninja -C build install
@@ -16,7 +16,7 @@ FROM ubuntu:18.04 AS buildtest-ubuntu1804-common
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt update && apt install -y automake autotools-dev make gcc libglib2.0-dev libcap-dev libseccomp-dev git ninja-build python3-pip
 RUN pip3 install meson
-RUN git clone https://gitlab.freedesktop.org/slirp/libslirp.git /libslirp
+RUN git clone git://git.qemu.org/libslirp.git /libslirp
 WORKDIR /libslirp
 ARG LIBSLIRP_COMMIT
 RUN  git pull && git checkout ${LIBSLIRP_COMMIT} && meson setup build && ninja -C build install
@@ -34,7 +34,7 @@ RUN ./configure && make && cp -f slirp4netns /
 FROM opensuse/leap:15 AS buildtest-opensuse15-common
 RUN zypper install -y --no-recommends autoconf automake gcc glib2-devel git make libcap-devel libseccomp-devel ninja python3-pip
 RUN pip3 install meson
-RUN git clone https://gitlab.freedesktop.org/slirp/libslirp.git /libslirp
+RUN git clone git://git.qemu.org/libslirp.git /libslirp
 WORKDIR /libslirp
 ARG LIBSLIRP_COMMIT
 RUN  git pull && git checkout ${LIBSLIRP_COMMIT} && meson setup --default-library=both build && ninja -C build install

--- a/Dockerfile.tests
+++ b/Dockerfile.tests
@@ -4,7 +4,7 @@ FROM ubuntu:20.04 AS build
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt update && apt install -y automake autotools-dev make gcc libglib2.0-dev libcap-dev libseccomp-dev git ninja-build python3-pip
 RUN pip3 install meson
-RUN git clone https://gitlab.freedesktop.org/slirp/libslirp.git /libslirp
+RUN git clone git://git.qemu.org/libslirp.git /libslirp
 WORKDIR /libslirp
 ARG LIBSLIRP_COMMIT
 RUN  git pull && git checkout ${LIBSLIRP_COMMIT} && meson setup build && ninja -C build install

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -34,7 +34,7 @@ Vagrant.configure("2") do |config|
         git clone --depth=1 --no-checkout https://github.com/seccomp/libseccomp
         git -C ./libseccomp fetch --tags --depth=1
 
-        git clone --depth=1 --no-checkout https://gitlab.freedesktop.org/slirp/libslirp.git
+        git clone --depth=1 --no-checkout git://git.qemu.org/libslirp.git
         git -C ./libslirp fetch --tags --depth=1
 
         touch ./build-and-test

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.69])
-AC_INIT([slirp4netns], [1.1.12+dev], [https://github.com/rootless-containers/slirp4netns/issues])
+AC_INIT([slirp4netns], [1.2.0-beta.0], [https://github.com/rootless-containers/slirp4netns/issues])
 AC_CONFIG_SRCDIR([main.c])
 AC_CONFIG_HEADERS([config.h])
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.69])
-AC_INIT([slirp4netns], [1.2.0-beta.0], [https://github.com/rootless-containers/slirp4netns/issues])
+AC_INIT([slirp4netns], [1.2.0-beta.0+dev], [https://github.com/rootless-containers/slirp4netns/issues])
 AC_CONFIG_SRCDIR([main.c])
 AC_CONFIG_HEADERS([config.h])
 

--- a/main.c
+++ b/main.c
@@ -83,6 +83,10 @@ static int open_tap(const char *tapname)
 {
     int fd;
     struct ifreq ifr;
+    if (tapname == NULL) {
+        fprintf(stderr, "tapname is NULL\n");
+        return -1;
+    }
     if ((fd = open("/dev/net/tun", O_RDWR)) < 0) {
         perror("open(\"/dev/net/tun\")");
         return fd;

--- a/main.c
+++ b/main.c
@@ -11,6 +11,7 @@
 #include <sys/ioctl.h>
 #include <sys/socket.h>
 #include <sys/types.h>
+#include <sys/un.h>
 #include <sys/wait.h>
 #include <linux/if_tun.h>
 #include <arpa/inet.h>
@@ -31,6 +32,7 @@
 #define DEFAULT_VNAMESERVER_OFFSET (3) // 10.0.2.3
 #define DEFAULT_RECOMMENDED_VGUEST_OFFSET (100) // 10.0.2.100
 #define DEFAULT_NETNS_TYPE ("pid")
+#define DEFAULT_TARGET_TYPE ("netns")
 #define NETWORK_PREFIX_MIN (1)
 // >=26 is not supported because the recommended guest IP is set to network addr
 // + 100 .
@@ -205,6 +207,7 @@ static int configure_network(const char *tapname,
     return 0;
 }
 
+/* Child (--target-type=netns) */
 static int child(int sock, pid_t target_pid, bool do_config_network,
                  const char *tapname, char *netns_path, char *userns_path,
                  struct slirp4netns_config *cfg)
@@ -227,6 +230,70 @@ static int child(int sock, pid_t target_pid, bool do_config_network,
     fprintf(stderr, "sent tapfd=%d for %s\n", tapfd, tapname);
     close(sock);
     return 0;
+}
+
+/*
+ * Child (--target-type=bess)
+ *
+ * FIXME: We do not really need to fork the child for BESS mode
+ */
+static int child_bess(int sock, const char *bess_socket)
+{
+    int bess_listenfd = -1, bess_acceptfd = -1;
+    struct sockaddr_un bess_listenaddr, bess_acceptaddr;
+    socklen_t bess_acceptaddrlen = sizeof(struct sockaddr_un);
+    memset(&bess_acceptaddr, 0, sizeof(bess_acceptaddr));
+    memset(&bess_listenaddr, 0, sizeof(bess_listenaddr));
+
+    /* Listen on the BESS socket */
+    if ((bess_listenfd = socket(AF_UNIX, SOCK_SEQPACKET, 0)) == -1) {
+        perror("child_bess: socket");
+        goto error;
+    }
+    bess_listenaddr.sun_family = AF_UNIX;
+    if (bess_socket == NULL) {
+        fprintf(stderr, "the specified BESS socket path is NULL\n");
+        goto error;
+    }
+    if (strlen(bess_socket) >= sizeof(bess_listenaddr.sun_path)) {
+        fprintf(stderr, "the specified BESS socket path is too long (>= %lu)\n",
+                sizeof(bess_listenaddr.sun_path));
+        goto error;
+    }
+    strncpy(bess_listenaddr.sun_path, bess_socket,
+            sizeof(bess_listenaddr.sun_path) - 1);
+    unlink(bess_socket); /* avoid EADDRINUSE */
+    if (bind(bess_listenfd, (struct sockaddr *)&bess_listenaddr,
+             sizeof(bess_listenaddr)) < 0) {
+        perror("child_bess: bind");
+        goto error;
+    }
+    if (listen(bess_listenfd, 0) < 0) {
+        perror("child_bess: listen");
+        goto error;
+    }
+
+    /* Accept a connection, and send its connection to the parent */
+    fprintf(stderr, "Waiting for connection to %s\n", bess_socket);
+    if ((bess_acceptfd =
+             accept(bess_listenfd, (struct sockaddr *)&bess_acceptaddr,
+                    &bess_acceptaddrlen)) < 0) {
+        perror("child_bess: accept");
+        goto error;
+    }
+    if (sendfd(sock, bess_acceptfd) < 0) {
+        goto error;
+    }
+    fprintf(stderr, "sent \"tapfd\"=%d (not really TAP) for %s\n",
+            bess_acceptfd, bess_socket);
+    close(sock);
+    close(bess_listenfd);
+    return 0;
+error:
+    close(bess_acceptfd);
+    close(bess_listenfd);
+    close(sock);
+    return -1;
 }
 
 static int recvfd(int sock)
@@ -341,7 +408,7 @@ static int parent(int sock, int ready_fd, int exit_fd, const char *api_socket,
 
 static void usage(const char *argv0)
 {
-    printf("Usage: %s [OPTION]... PID|PATH TAPNAME\n", argv0);
+    printf("Usage: %s [OPTION]... PID|PATH [TAPNAME]\n", argv0);
     printf("User-mode networking for unprivileged network namespaces.\n\n");
     printf("-c, --configure          bring up the interface\n");
     printf("-e, --exit-fd=FD         specify the FD for terminating "
@@ -380,8 +447,13 @@ static void usage(const char *argv0)
     printf("--disable-dns            disables 10.0.2.3 (or configured internal "
            "ip) to host dns redirect (experimental)\n");
 #endif
+    /* v1.1.9 */
     printf("--macaddress=MAC         specify the MAC address of the TAP (only "
            "valid with -c)\n");
+    /* v1.2.0 */
+    printf("--target-type=TYPE       specify the target type ([netns|bess], "
+           "default=%s)\n",
+           DEFAULT_TARGET_TYPE);
     /* others */
     printf("-h, --help               show this help and exit\n");
     printf("-v, --version            show version and exit\n");
@@ -424,6 +496,8 @@ struct options {
     bool enable_seccomp; // --enable-seccomp
     bool disable_dns; // --disable-dns
     char *macaddress; // --macaddress
+    char *target_type; // --target-type
+    char *bess_socket; // argv[1] (When --target-type="bess")
 };
 
 static void options_init(struct options *options)
@@ -471,6 +545,14 @@ static void options_destroy(struct options *options)
         free(options->macaddress);
         options->macaddress = NULL;
     }
+    if (options->target_type != NULL) {
+        free(options->target_type);
+        options->target_type = NULL;
+    }
+    if (options->bess_socket != NULL) {
+        free(options->bess_socket);
+        options->bess_socket = NULL;
+    }
 }
 
 // * caller does not need to call options_init()
@@ -487,6 +569,7 @@ static void parse_args(int argc, char *const argv[], struct options *options)
     char *optarg_outbound_addr = NULL;
     char *optarg_outbound_addr6 = NULL;
     char *optarg_macaddress = NULL;
+    char *optarg_target_type = NULL;
 #define CIDR -42
 #define DISABLE_HOST_LOOPBACK -43
 #define NETNS_TYPE -44
@@ -497,6 +580,7 @@ static void parse_args(int argc, char *const argv[], struct options *options)
 #define OUTBOUND_ADDR6 -49
 #define DISABLE_DNS -50
 #define MACADDRESS -51
+#define TARGET_TYPE -52
 #define _DEPRECATED_NO_HOST_LOOPBACK \
     -10043 // deprecated in favor of disable-host-loopback
 #define _DEPRECATED_CREATE_SANDBOX \
@@ -522,6 +606,7 @@ static void parse_args(int argc, char *const argv[], struct options *options)
         { "outbound-addr6", required_argument, NULL, OUTBOUND_ADDR6 },
         { "disable-dns", no_argument, NULL, DISABLE_DNS },
         { "macaddress", required_argument, NULL, MACADDRESS },
+        { "target-type", required_argument, NULL, TARGET_TYPE },
         { 0, 0, 0, 0 },
     };
     options_init(options);
@@ -624,6 +709,9 @@ static void parse_args(int argc, char *const argv[], struct options *options)
         case MACADDRESS:
             optarg_macaddress = optarg;
             break;
+        case TARGET_TYPE:
+            optarg_target_type = optarg;
+            break;
         default:
             goto error;
             break;
@@ -656,6 +744,9 @@ static void parse_args(int argc, char *const argv[], struct options *options)
             options->macaddress = strdup(optarg_macaddress);
         }
     }
+    if (optarg_target_type != NULL) {
+        options->target_type = strdup(optarg_target_type);
+    }
 #undef CIDR
 #undef DISABLE_HOST_LOOPBACK
 #undef NETNS_TYPE
@@ -667,8 +758,48 @@ static void parse_args(int argc, char *const argv[], struct options *options)
 #undef OUTBOUND_ADDR6
 #undef DISABLE_DNS
 #undef MACADDRESS
+#undef TARGET_TYPE
+
+    /* BESS mode */
+    if (options->target_type != NULL &&
+        strcmp(options->target_type, "bess") == 0) {
+        if (argc - optind < 1) {
+            goto error;
+        }
+        if (argc - optind > 1) {
+            fprintf(stderr, "too many arguments\n");
+            goto error;
+        }
+        options->bess_socket = strdup(argv[optind]);
+        if (options->do_config_network) {
+            fprintf(stderr, "--configure conflicts with --target-type=bess\n");
+            goto error;
+        }
+        if (options->netns_type != NULL) {
+            fprintf(stderr, "--netns-type conflicts with --target-type=bess\n");
+            goto error;
+        }
+        if (options->userns_path != NULL) {
+            fprintf(stderr,
+                    "--userns-path conflicts with --target-type=bess\n");
+            goto error;
+        }
+        printf("WARNING: BESS mode is experimental\n");
+        return;
+    }
+
+    /* NetNS mode*/
+    if (options->target_type != NULL &&
+        strcmp(options->target_type, "netns") != 0) {
+        fprintf(stderr, "--target-type must be either \"netns\" or \"bess\"\n");
+        goto error;
+    }
     if (argc - optind < 2) {
         goto error;
+    }
+    if (argc - optind > 2) {
+        // not an error, for preventing potential compatibility issue
+        printf("WARNING: too many arguments\n");
     }
     if (!options->netns_type ||
         strcmp(options->netns_type, DEFAULT_NETNS_TYPE) == 0) {
@@ -970,9 +1101,16 @@ int main(int argc, char *const argv[])
         goto finish;
     }
     if (child_pid == 0) {
-        if (child(sv[1], options.target_pid, options.do_config_network,
-                  options.tapname, options.netns_path, options.userns_path,
-                  &slirp4netns_config) < 0) {
+        int ret;
+        if (options.target_type != NULL &&
+            strcmp(options.target_type, "bess") == 0) {
+            ret = child_bess(sv[1], options.bess_socket);
+        } else {
+            ret = child(sv[1], options.target_pid, options.do_config_network,
+                        options.tapname, options.netns_path,
+                        options.userns_path, &slirp4netns_config);
+        }
+        if (ret < 0) {
             exit_status = EXIT_FAILURE;
             goto finish;
         }

--- a/slirp4netns.1
+++ b/slirp4netns.1
@@ -1,5 +1,5 @@
 .nh
-.TH SLIRP4NETNS 1 "June 2021" "Rootless Containers" "User Commands"
+.TH SLIRP4NETNS 1 "January 2022" "Rootless Containers" "User Commands"
 
 .SH NAME
 .PP
@@ -8,7 +8,7 @@ slirp4netns \- User\-mode networking for unprivileged network namespaces
 
 .SH SYNOPSIS
 .PP
-slirp4netns [OPTION]... PID|PATH TAPNAME
+slirp4netns [OPTION]... PID|PATH [TAPNAME]
 
 
 .SH DESCRIPTION
@@ -130,6 +130,14 @@ disable built\-in DNS (10.0.2.3 by default)
 .PP
 \fB\fC\-\-macaddress\fR (since v1.1.9)
 specify MAC address of the TAP interface (only valid with \-c)
+
+.PP
+\fB\fC\-\-target\-type=TYPE\fR (since v1.2.0)
+specify the target type ([netns|bess], default=netns).
+
+.PP
+The \fB\fCbess\fR mode (since v1.2.0, EXPERIMENTAL) is expected to be used with User Mode Linux.
+The \fB\fCbess\fR mode conflicts with \fB\fC\-\-configure\fR, \fB\fC\-\-netns\-type\fR, and \fB\fC\-\-userns\-path\fR\&.
 
 .PP
 \fB\fC\-h\fR, \fB\fC\-\-help\fR (since v0.2.0)
@@ -481,6 +489,44 @@ To allow communication across multiple slirp4netns instances, you need to combin
 .PP
 VXLAN is known to work.
 See Usernetes project for the example of multi\-node rootless Kubernetes cluster with VXLAN: \fB\fChttps://github.com/rootless\-containers/usernetes\fR
+
+
+.SH BESS MODE (FOR USER MODE LINUX)
+.PP
+slirp4netns (since v1.2.0) can be also used as a BESS\-compatible server to provide network connectivity to User Mode Linux.
+
+.PP
+\fBTerminal 1\fP: Start slirp4netns
+
+.PP
+.RS
+
+.nf
+(host)$ slirp4netns \-\-target\-type=bess /tmp/bess.sock
+
+.fi
+.RE
+
+.PP
+\fBTerminal 2\fP: Start User Mode Linux
+
+.PP
+.RS
+
+.nf
+(host)$ linux.uml vec0:transport=bess,dst=/tmp/bess.sock,depth=128,gro=1 root=/dev/root rootfstype=hostfs init=/bin/bash mem=2G
+(UML)$ ip addr add 10.0.2.100/24 dev vec0
+(UML)$ ip link set vec0 up
+(UML)$ ip route add default via 10.0.2.2
+
+.fi
+.RE
+
+.PP
+Currently, only a single instance of User Mode Linux can be connected to the slirp4netns BESS server.
+
+.PP
+See also User Mode Linux documentation: \fB\fChttps://www.kernel.org/doc/html/latest/virt/uml/user\_mode\_linux\_howto\_v2.html#bess\-socket\-transport\fR
 
 
 .SH BUGS

--- a/slirp4netns.1.md
+++ b/slirp4netns.1.md
@@ -1,4 +1,4 @@
-SLIRP4NETNS 1 "June 2021" "Rootless Containers" "User Commands"
+SLIRP4NETNS 1 "January 2022" "Rootless Containers" "User Commands"
 ==================================================
 
 # NAME
@@ -7,7 +7,7 @@ slirp4netns - User-mode networking for unprivileged network namespaces
 
 # SYNOPSIS
 
-slirp4netns [OPTION]... PID|PATH TAPNAME
+slirp4netns [OPTION]... PID|PATH [TAPNAME]
 
 # DESCRIPTION
 
@@ -94,6 +94,12 @@ disable built-in DNS (10.0.2.3 by default)
 
 `--macaddress` (since v1.1.9)
 specify MAC address of the TAP interface (only valid with -c)
+
+`--target-type=TYPE` (since v1.2.0)
+specify the target type ([netns|bess], default=netns).
+
+The `bess` mode (since v1.2.0, EXPERIMENTAL) is expected to be used with User Mode Linux.
+The `bess` mode conflicts with `--configure`, `--netns-type`, and `--userns-path`.
 
 `-h`, `--help` (since v0.2.0)
 show help and exit
@@ -314,6 +320,28 @@ To allow communication across multiple slirp4netns instances, you need to combin
 
 VXLAN is known to work.
 See Usernetes project for the example of multi-node rootless Kubernetes cluster with VXLAN: `https://github.com/rootless-containers/usernetes`
+
+# BESS MODE (FOR USER MODE LINUX)
+slirp4netns (since v1.2.0) can be also used as a BESS-compatible server to provide network connectivity to User Mode Linux.
+
+**Terminal 1**: Start slirp4netns
+
+```console
+(host)$ slirp4netns --target-type=bess /tmp/bess.sock
+```
+
+**Terminal 2**: Start User Mode Linux
+
+```console
+(host)$ linux.uml vec0:transport=bess,dst=/tmp/bess.sock,depth=128,gro=1 root=/dev/root rootfstype=hostfs init=/bin/bash mem=2G
+(UML)$ ip addr add 10.0.2.100/24 dev vec0
+(UML)$ ip link set vec0 up
+(UML)$ ip route add default via 10.0.2.2
+```
+
+Currently, only a single instance of User Mode Linux can be connected to the slirp4netns BESS server.
+
+See also User Mode Linux documentation: `https://www.kernel.org/doc/html/latest/virt/uml/user_mode_linux_howto_v2.html#bess-socket-transport`
 
 # BUGS
 


### PR DESCRIPTION
BESS protocol transferrs L2 packets as AF_UNIX SOCK_SEQPACKET .
BESS protocol has been used by the vector network interfaces of User Mode Linux (UML).

```
(terminal 1) $ slirp4netns --target-type=bess /tmp/bess.sock
(terminal 2) $ linux.uml vec0:transport=bess,dst=/tmp/bess.sock,depth=128,gro=1 root=/dev/root rootfstype=hostfs init=/bin/bash mem=2G
(terminal 2: UML)$ ip addr add 10.0.2.100/24 dev vec0
(terminal 2: UML)$ ip link set vec0 up
(terminal 2: UML)$ ip route add default via 10.0.2.2
```

More docs about the User Mode Linux with BESS socket transport: https://www.kernel.org/doc/html/latest/virt/uml/user_mode_linux_howto_v2.html#bess-socket-transport

