### PR TITLE
Add support for escaping resolv.conf symlinks

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,21 +5,22 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
-    - uses: docker/setup-buildx-action@v1
+    - uses: docker/setup-qemu-action@v2
+    - uses: docker/setup-buildx-action@v2
     - name: "Build binaries from Dockerfile.artifact"
-      run: docker buildx build -o /tmp --platform=amd64,arm64,arm,s390x,ppc64le,riscv64 -f Dockerfile.artifact .
+      run: docker buildx build -o /tmp/slirpbuilds --platform=amd64,arm64,arm,s390x,ppc64le,riscv64 -f Dockerfile.artifact .
     - name: "Create /tmp/artifact"
       run: |
         mkdir -p /tmp/artifact
-        mv /tmp/linux_amd64/slirp4netns /tmp/artifact/slirp4netns-x86_64
-        mv /tmp/linux_arm64/slirp4netns /tmp/artifact/slirp4netns-aarch64
-        mv /tmp/linux_arm_v7/slirp4netns /tmp/artifact/slirp4netns-armv7l
-        mv /tmp/linux_s390x/slirp4netns /tmp/artifact/slirp4netns-s390x
-        mv /tmp/linux_ppc64le/slirp4netns /tmp/artifact/slirp4netns-ppc64le
-        mv /tmp/linux_riscv64/slirp4netns /tmp/artifact/slirp4netns-riscv64
+        mv /tmp/slirpbuilds/linux_amd64/slirp4netns /tmp/artifact/slirp4netns-x86_64
+        mv /tmp/slirpbuilds/linux_arm64/slirp4netns /tmp/artifact/slirp4netns-aarch64
+        mv /tmp/slirpbuilds/linux_arm_v7/slirp4netns /tmp/artifact/slirp4netns-armv7l
+        mv /tmp/slirpbuilds/linux_s390x/slirp4netns /tmp/artifact/slirp4netns-s390x
+        mv /tmp/slirpbuilds/linux_ppc64le/slirp4netns /tmp/artifact/slirp4netns-ppc64le
+        mv /tmp/slirpbuilds/linux_riscv64/slirp4netns /tmp/artifact/slirp4netns-riscv64
     - name: "SHA256SUMS"
       run: (cd /tmp/artifact; sha256sum *) | tee /tmp/SHA256SUMS
     - name: "The sha256sum of the SHA256SUMS file"

--- a/Dockerfile.buildtests
+++ b/Dockerfile.buildtests
@@ -3,7 +3,7 @@ ARG LIBSLIRP_COMMIT=v4.7.0
 # Alpine
 FROM alpine:3 AS buildtest-alpine3-static
 RUN apk add --no-cache git build-base autoconf automake libtool linux-headers glib-dev glib-static libcap-static libcap-dev libseccomp-dev libseccomp-static git meson
-RUN git clone git://git.qemu.org/libslirp.git /libslirp
+RUN git clone https://git.qemu.org/libslirp.git /libslirp
 WORKDIR /libslirp
 ARG LIBSLIRP_COMMIT
 RUN  git pull && git checkout ${LIBSLIRP_COMMIT} && meson setup --default-library=both build && ninja -C build install
@@ -16,7 +16,7 @@ FROM ubuntu:18.04 AS buildtest-ubuntu1804-common
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt update && apt install -y automake autotools-dev make gcc libglib2.0-dev libcap-dev libseccomp-dev git ninja-build python3-pip
 RUN pip3 install meson
-RUN git clone git://git.qemu.org/libslirp.git /libslirp
+RUN git clone https://git.qemu.org/libslirp.git /libslirp
 WORKDIR /libslirp
 ARG LIBSLIRP_COMMIT
 RUN  git pull && git checkout ${LIBSLIRP_COMMIT} && meson setup build && ninja -C build install
@@ -34,7 +34,7 @@ RUN ./configure && make && cp -f slirp4netns /
 FROM opensuse/leap:15 AS buildtest-opensuse15-common
 RUN zypper install -y --no-recommends autoconf automake gcc glib2-devel git make libcap-devel libseccomp-devel ninja python3-pip
 RUN pip3 install meson
-RUN git clone git://git.qemu.org/libslirp.git /libslirp
+RUN git clone https://git.qemu.org/libslirp.git /libslirp
 WORKDIR /libslirp
 ARG LIBSLIRP_COMMIT
 RUN  git pull && git checkout ${LIBSLIRP_COMMIT} && meson setup --default-library=both build && ninja -C build install

--- a/Dockerfile.tests
+++ b/Dockerfile.tests
@@ -4,7 +4,7 @@ FROM ubuntu:22.04 AS build
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt update && apt install -y automake autotools-dev make gcc libglib2.0-dev libcap-dev libseccomp-dev git ninja-build python3-pip
 RUN pip3 install meson
-RUN git clone git://git.qemu.org/libslirp.git /libslirp
+RUN git clone https://git.qemu.org/libslirp.git /libslirp
 WORKDIR /libslirp
 ARG LIBSLIRP_COMMIT
 RUN  git pull && git checkout ${LIBSLIRP_COMMIT} && meson setup build && ninja -C build install

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -34,7 +34,7 @@ Vagrant.configure("2") do |config|
         git clone --depth=1 --no-checkout https://github.com/seccomp/libseccomp
         git -C ./libseccomp fetch --tags --depth=1
 
-        git clone --depth=1 --no-checkout git://git.qemu.org/libslirp.git
+        git clone --depth=1 --no-checkout https://git.qemu.org/libslirp.git
         git -C ./libslirp fetch --tags --depth=1
 
         touch ./build-and-test


### PR DESCRIPTION
Previously if resolv.conf was symlinked to a location other than /etc, or /run, a warning message would be printed and DNS would be non-functional.

Instead, attempt to bind an equivalent resolv.conf link target path in the namespace structure, so that symlink continues to function, and DNS remains operational.

This fixes usage in WSL environments which symlinks /etc/resolv.conf under a shared location under /mnt. Although I suspect this usage pattern is fairly common in other environments. 

Alternatively, instead of mirroring the target path,  this could have utilized the newer open_tree/move_mount syscalls, to bind mount on top of the /etc/resolv.conf symlink. However, this would have limited the support to 5.2 kernels and later, so just cloning the target seemed the way to go. 

Note: this PR also includes some commits to fix CI