### PR TITLE
CI: Re-remove usage of qemu-setup-action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,7 +8,6 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
-    - uses: docker/setup-qemu-action@v2
     - uses: docker/setup-buildx-action@v2
     - name: "Build binaries from Dockerfile.artifact"
       run: docker buildx build -o /tmp/slirpbuilds --platform=amd64,arm64,arm,s390x,ppc64le,riscv64 -f Dockerfile.artifact .


### PR DESCRIPTION
As part of my last PR, this was pulled in as part of the buildx setup updates to fix the release job, but was not strictly necessary.

(The primary original issue was buildx tripping over other directories created by other processes in it's output path (/tmp)that it didn't have permission to access)