### PR TITLE
Enable reproducible builds

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,7 +7,11 @@ jobs:
   release:
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
+      with:
+        # Reproduce the exact commit hash value
+        fetch-depth: 0
+        ref: ${{ github.event.pull_request.head.sha }}
     - run: echo "SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)" >> $GITHUB_ENV
     - uses: docker/setup-buildx-action@v2
     - name: Cache var-cache-apt

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,6 +8,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
+    - run: echo "SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)" >> $GITHUB_ENV
     - uses: docker/setup-buildx-action@v2
     - name: Cache var-cache-apt
       uses: actions/cache@v3
@@ -30,7 +31,7 @@ jobs:
         cache-source: var-lib-apt
         cache-target: /var/lib/apt
     - name: "Build binaries from Dockerfile.artifact"
-      run: docker buildx build -o /tmp/slirpbuilds --platform=amd64,arm64,arm,s390x,ppc64le,riscv64 -f Dockerfile.artifact .
+      run: docker buildx build -o /tmp/slirpbuilds --build-arg SOURCE_DATE_EPOCH --platform=amd64,arm64,arm,s390x,ppc64le,riscv64 -f Dockerfile.artifact .
     - name: extract var-cache-apt into docker
       uses: overmindtech/buildkit-cache-dance/extract@306d31a77191f643c0c4a95083f36c6ddccb4a16
       with:
@@ -50,6 +51,7 @@ jobs:
         mv /tmp/slirpbuilds/linux_s390x/slirp4netns /tmp/artifact/slirp4netns-s390x
         mv /tmp/slirpbuilds/linux_ppc64le/slirp4netns /tmp/artifact/slirp4netns-ppc64le
         mv /tmp/slirpbuilds/linux_riscv64/slirp4netns /tmp/artifact/slirp4netns-riscv64
+        echo "${SOURCE_DATE_EPOCH}" >/tmp/artifact/SOURCE_DATE_EPOCH
     - name: "SHA256SUMS"
       run: (cd /tmp/artifact; sha256sum *) | tee /tmp/SHA256SUMS
     - name: "The sha256sum of the SHA256SUMS file"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -86,6 +86,16 @@ jobs:
         The build log is available for 90 days: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
         The sha256sum of the SHA256SUMS file itself is \`${shasha}\` .
+
+        The binaries should be reproducible with the following command:
+        \`\`\`
+        docker buildx build \
+          -o /tmp/slirpbuilds \
+          --build-arg SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH} \
+          --platform=amd64,arm64,arm,s390x,ppc64le,riscv64 \
+          -f Dockerfile.artifact \
+          "https://github.com/${{ github.repository }}.git#${{ github.event.pull_request.head.sha }}"
+        \`\`\`
         EOF
     - name: "Create release"
       if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,8 +9,38 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: docker/setup-buildx-action@v2
+    - name: Cache var-cache-apt
+      uses: actions/cache@v3
+      with:
+        path: var-cache-apt
+        key: var-cache-apt-${{ hashFiles('Dockerfile.artifact') }}
+    - name: Cache var-lib-apt
+      uses: actions/cache@v3
+      with:
+        path: var-lib-apt
+        key: var-lib-apt-${{ hashFiles('Dockerfile.artifact') }}
+    - name: inject var-cache-apt into docker
+      uses: overmindtech/buildkit-cache-dance/inject@306d31a77191f643c0c4a95083f36c6ddccb4a16
+      with:
+        cache-source: var-cache-apt
+        cache-target: /var/cache/apt
+    - name: inject var-lib-apt into docker
+      uses: overmindtech/buildkit-cache-dance/inject@306d31a77191f643c0c4a95083f36c6ddccb4a16
+      with:
+        cache-source: var-lib-apt
+        cache-target: /var/lib/apt
     - name: "Build binaries from Dockerfile.artifact"
       run: docker buildx build -o /tmp/slirpbuilds --platform=amd64,arm64,arm,s390x,ppc64le,riscv64 -f Dockerfile.artifact .
+    - name: extract var-cache-apt into docker
+      uses: overmindtech/buildkit-cache-dance/extract@306d31a77191f643c0c4a95083f36c6ddccb4a16
+      with:
+        cache-source: var-cache-apt
+        cache-target: /var/cache/apt
+    - name: extract var-lib-apt into docker
+      uses: overmindtech/buildkit-cache-dance/extract@306d31a77191f643c0c4a95083f36c6ddccb4a16
+      with:
+        cache-source: var-lib-apt
+        cache-target: /var/lib/apt
     - name: "Create /tmp/artifact"
       run: |
         mkdir -p /tmp/artifact

--- a/Dockerfile.artifact
+++ b/Dockerfile.artifact
@@ -1,19 +1,38 @@
 ARG LIBSLIRP_COMMIT=v4.7.0
-ARG UBUNTU_VERSION=22.04
+ARG UBUNTU_VERSION=jammy-20230804
 ARG XX_VERSION=1.2.1@sha256:8879a398dedf0aadaacfbd332b29ff2f84bc39ae6d4e9c0a1109db27ac5ba012
+ARG REPRO_SOURCES_LIST_VERSION=v0.1.0
 
 FROM --platform=$BUILDPLATFORM tonistiigi/xx:${XX_VERSION} AS xx
 
 FROM --platform=$BUILDPLATFORM ubuntu:${UBUNTU_VERSION} AS build-libslirp
+ARG REPRO_SOURCES_LIST_VERSION
+ADD --chmod=0755 \
+  https://raw.githubusercontent.com/reproducible-containers/repro-sources-list.sh/${REPRO_SOURCES_LIST_VERSION}/repro-sources-list.sh \
+  /usr/local/bin/repro-sources-list.sh
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update && apt-get install -y apt-utils automake autotools-dev make git ninja-build meson
+RUN \
+  --mount=type=cache,target=/var/cache/apt,sharing=locked \
+  --mount=type=cache,target=/var/lib/apt,sharing=locked \
+  repro-sources-list.sh && \
+  apt-get update && \
+  apt-get install -y apt-utils automake autotools-dev file make git ninja-build meson
 RUN git clone https://git.qemu.org/libslirp.git /libslirp
 WORKDIR /libslirp
 ARG LIBSLIRP_COMMIT
 RUN  git pull && git checkout ${LIBSLIRP_COMMIT}
 COPY --from=xx / /
 ARG TARGETPLATFORM
-RUN xx-apt-get install -y gcc libglib2.0-dev libcap-dev libseccomp-dev
+# xx-apt-get cannot be used, as it clobbers /etc/apt/sources.list created by repro-sources-list.sh
+RUN \
+  --mount=type=cache,target=/var/cache/apt,sharing=locked \
+  --mount=type=cache,target=/var/lib/apt,sharing=locked \
+  darch="$(xx-info debian-arch)" && \
+  dpkg --add-architecture ${darch} && \
+  apt-get update && \
+  gcc="gcc" && \
+  if xx-info is-cross; then gcc="gcc-$(xx-info triple)"; fi; \
+  apt-get install -y "${gcc}" "libglib2.0-dev:${darch}" "libcap-dev:${darch}" "libseccomp-dev:${darch}"
 COPY Dockerfile.artifact.d/meson-cross /meson-cross
 RUN meson_setup_flags="--default-library=both" ; \
  if xx-info is-cross; then meson_setup_flags="${meson_setup_flags} --cross-file=/meson-cross/$(xx-info) -Dprefix=/usr/local/$(xx-info)"; fi ; \

--- a/Dockerfile.artifact
+++ b/Dockerfile.artifact
@@ -1,3 +1,10 @@
+# Usage:
+# docker buildx build \
+#   -o /tmp/slirpbuilds \
+#   --build-arg SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct) \
+#   --platform=amd64,arm64,arm,s390x,ppc64le,riscv64 \
+#   -f Dockerfile.artifact .
+
 ARG LIBSLIRP_COMMIT=v4.7.0
 ARG UBUNTU_VERSION=jammy-20230804
 ARG XX_VERSION=1.2.1@sha256:8879a398dedf0aadaacfbd332b29ff2f84bc39ae6d4e9c0a1109db27ac5ba012
@@ -17,6 +24,8 @@ RUN \
   repro-sources-list.sh && \
   apt-get update && \
   apt-get install -y apt-utils automake autotools-dev file make git ninja-build meson
+# Set SOURCE_DATE_EPOCH after running repro-sources-list.sh, for cache efficiency
+ARG SOURCE_DATE_EPOCH
 RUN git clone https://git.qemu.org/libslirp.git /libslirp
 WORKDIR /libslirp
 ARG LIBSLIRP_COMMIT


### PR DESCRIPTION
Binaries should be reproducible with:
```bash
 docker buildx build \
   -o /tmp/slirpbuilds \
   --build-arg SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct) \
   --platform=amd64,arm64,arm,s390x,ppc64le,riscv64 \
   -f Dockerfile.artifact .
```