### PR TITLE
Do not leak socket in case of success.

### DIFF
--- a/main.c
+++ b/main.c
@@ -225,6 +225,7 @@ static int configure_network(const char *tapname,
         perror("set route");
         goto fail;
     }
+    close(sockfd);
     return 0;
 fail:
     close(sockfd);


### PR DESCRIPTION
There seems to be a socket leak in case of success in configure_network() function. This simple patch fixes this.