### PR TITLE
CI: Enable actions/attest-build-provenance@v2

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,6 +6,12 @@ on:
 jobs:
   release:
     runs-on: ubuntu-24.04
+    # The maximum access is "read" for PRs from public forked repos
+    # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
+    permissions:
+      contents: write  # for releases
+      id-token: write  # for provenances
+      attestations: write  # for provenances
     steps:
     - uses: actions/checkout@v4
       with:
@@ -83,6 +89,12 @@ jobs:
           "https://github.com/${{ github.repository }}.git#${tag}"
         \`\`\`
         EOF
+    - uses: actions/attest-build-provenance@v2
+      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+      with:
+        subject-path: |
+          /tmp/artifact/*
+          /tmp/SHA256SUMS
     - name: "Create release"
       if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
       env:


### PR DESCRIPTION
https://github.com/actions/attest-build-provenance

https://github.blog/changelog/2024-06-25-artifact-attestations-is-generally-available/
