### PR TITLE
CI: temporarily disable release check for PRs

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,7 +1,6 @@
 name: Release
 on:
   push:
-  pull_request:
 
 jobs:
   release:


### PR DESCRIPTION
Not likely compromised so far, but temporarily disable the check during investigation.