### PR TITLE
Revert "CI: temporarily disable release check for PRs"

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,6 +1,7 @@
 name: Release
 on:
   push:
+  pull_request:
 
 jobs:
   release:


### PR DESCRIPTION
Revert:
- #359

I was overreacting to https://www.stepsecurity.io/blog/hackerbot-claw-github-actions-exploitation .
We were not vulnerable because we had no workflows that permitted triggers from `pull_request_target`, `issue_comment`, or anything similar events.